### PR TITLE
New: Filter out expected errors (fixes #4)

### DIFF
--- a/lib/processor.js
+++ b/lib/processor.js
@@ -2,6 +2,7 @@
  * @fileoverview Processes Markdown files for consumption by ESLint.
  * @author Brandon Mills
  * @copyright 2015 Brandon Mills. All rights reserved.
+ * @copyright 2015 Ian VanSchooten. All rights reserved.
  */
 
 "use strict";
@@ -9,6 +10,7 @@
 var assign = require("object-assign");
 
 var blocks = [];
+var expectedErrors;
 
 /**
  * Parses Markdown text for fenced code blocks containing JS.
@@ -26,7 +28,10 @@ function parse(text) {
         line = 0,
         column = 0,
         mode = modes.NORMAL,
-        next;
+        next,
+        expErr;
+
+    var EXP_ERR_REGEX = /\/\*\s*error\s+(.+?)\s*\*\//g;
 
     /**
      * Attempts to match a regex and advances if successful.
@@ -84,10 +89,10 @@ function parse(text) {
     }
 
     while (index < text.length) {
-        if (match(/^\r?\n/)) {
+        if (match(/^\r?\n/)) { // Newline
             line += 1;
             column = 0;
-        } else if (
+        } else if ( // Start of a fenced javascript or js code block
             mode === modes.NORMAL &&
             (next = match(/^((?: {4}|\t)*)```j(?:s|avascript)\r?\n/i))
         ) {
@@ -116,6 +121,15 @@ function parse(text) {
             next = match(/[^\r\n]*/);
             column += next[0].length;
         }
+
+        // Capture expected errors
+        while (
+            mode === modes.CODE &&
+            (expErr = EXP_ERR_REGEX.exec(text.slice(index).split("\n")[0])) !== null
+        ) {
+            expectedErrors[line + 1] = expectedErrors[line + 1] || [];
+            expectedErrors[line + 1].push(expErr[1]);
+        }
     }
 
     // Finish an unclosed code fence
@@ -132,6 +146,7 @@ function parse(text) {
  * @returns {[string]} Code blocks to lint.
  */
 function preprocess(text) {
+    expectedErrors = {};
     blocks = parse(text);
     return blocks.map(function(block) {
         return block.text;
@@ -145,6 +160,21 @@ function preprocess(text) {
  * @returns {Message[]} A flattened array of messages with mapped locations.
  */
 function postprocess(messages) {
+
+    /**
+     * Returns messages which are not in the list of expected errors
+     * @param  {Message[]}  msgs A flattened array of messages with mapped locations.
+     * @returns {Message[]}      An array of messages without expected messages.
+     */
+    function getUnexpectedMessages(msgs) {
+        return msgs.filter(function (error) {
+            if (!expectedErrors[error.line]) {
+                return true;
+            }
+            return (expectedErrors[error.line].indexOf(error.message) === -1);
+        });
+    }
+
     function translate(block, message) {
         return assign({}, message, {
             line: message.line + block.loc.start.line,
@@ -152,9 +182,11 @@ function postprocess(messages) {
         });
     }
 
-    return [].concat.apply([], messages.map(function(group, index) {
+    var mappedMessages = [].concat.apply([], messages.map(function(group, index) {
         return group.map(translate.bind(null, blocks[index]));
     }));
+
+    return getUnexpectedMessages(mappedMessages);
 }
 
 module.exports = {


### PR DESCRIPTION
This is a rough, non-unit-tested cut at preventing some error messages from being reported by the plugin.

To keep a message from being reported:

* The message must be placed on the same line that ESLint would report the error on.
* The message must be in multiline comment format (`/* */`)
* The message must start with `error`
* Multiple messages can be used on the same line.  Each must follow the format above.
* The message must match the message *as reported*, not necessarily as displayed.  For instance, the stylish reporter seems to strip trailing full stops (`.`).  Some flexibility should probably be added to the check in this regard.

I'm not terribly happy with the implementation of `getUnexpectedMessages()`, and I would love to know a better way to accomplish omitting messages which are expected, if there is one.
