### PR TITLE
Breaking: CommonMark-compatible code fences (fixes #2)

### DIFF
--- a/lib/processor.js
+++ b/lib/processor.js
@@ -49,11 +49,58 @@ function parse(text) {
     }
 
     /**
+     * Tries to match an opening code fence on the current line.
+     * @returns {object|boolean} Fence data or false if no match.
+     */
+    function matchOpeningCodeFence() {
+        var captures;
+
+        // Exit early if an opening fence is not expected.
+        if (mode !== modes.NORMAL) {
+            return false;
+        }
+
+        captures = match(/^( {0,3})(`{3,}|~{3,})\h*(?:js|javascript)\h*\r?\n/i);
+        if (captures) {
+            return {
+                indent: captures[1],
+                fence: captures[2]
+            };
+        }
+
+        return false;
+    }
+
+    /**
+     * Tries to match a closing code fence on the current line.
+     * @returns {string[]|boolean} Match result or false if no match.
+     */
+    function matchClosingCodeFence() {
+        var block, regexp;
+
+        // Exit early if a closing fence is not expected.
+        if (mode !== modes.CODE) {
+            return false;
+        }
+
+        block = result[result.length - 1];
+        regexp = [
+            "^ {0,3}",
+            block.fence[0],
+            "{",
+            block.fence.length,
+            ",}\\h*(?:\\r?\\n|$)"
+        ].join("");
+        return match(new RegExp(regexp));
+    }
+
+    /**
      * Starts a new block and pushes it onto the result list.
      * @param {string} indent The indent used for this block.
+     * @param {string} fence The backticks or tildes used to start the block.
      * @returns {void}
      */
-    function startBlock(indent) {
+    function startBlock(indent, fence) {
         result.push({
             range: [index],
             loc: {
@@ -62,7 +109,8 @@ function parse(text) {
                     column: indent.length
                 }
             },
-            indent: indent
+            indent: indent,
+            fence: fence
         });
 
         mode = modes.CODE;
@@ -81,42 +129,39 @@ function parse(text) {
             line: line,
             column: column || block.indent.length
         };
-        block.text = text
-            .slice(block.range[0], block.range[1])
-            .replace(new RegExp("^" + block.indent, "gm"), "");
+        block.rawText = text.slice(block.range[0], block.range[1]);
+
+        if (block.indent.length > 0) {
+            block.text = block.rawText.replace(new RegExp("^ {1," + block.indent.length + "}", "gm"), "");
+        } else {
+            block.text = block.rawText;
+        }
 
         mode = modes.NORMAL;
     }
 
     while (index < text.length) {
-        if (match(/^\r?\n/)) { // Newline
-            line += 1;
-            column = 0;
-        } else if ( // Start of a fenced javascript or js code block
-            mode === modes.NORMAL &&
-            (next = match(/^((?: {4}|\t)*)```j(?:s|avascript)\r?\n/i))
-        ) {
+
+        // Newline
+        if (match(/^\r?\n/)) {
             line += 1;
             column = 0;
 
-            startBlock(next[1]);
-        } else if ( // Closing fence at end of file
-            mode === modes.CODE &&
-            (next = match(new RegExp(
-                "^" + result[result.length - 1].indent + "(```)$"
-            )))
-        ) {
-            finishBlock(next[1].length);
-        } else if ( // Closing fence before newline
-            mode === modes.CODE &&
-            (next = match(new RegExp(
-                "^" + result[result.length - 1].indent + "(```\r?\n)"
-            )))
-        ) {
-            finishBlock(next[1].length);
+        // Opening code fence
+        } else if ((next = matchOpeningCodeFence())) {
+            line += 1;
+            column = 0;
+
+            startBlock(next.indent, next.fence);
+
+        // Closing code fence
+        } else if ((next = matchClosingCodeFence())) {
+            finishBlock(next[0].length);
 
             line += 1;
             column = 0;
+
+        // Line content
         } else {
             next = match(/[^\r\n]*/);
             column += next[0].length;
@@ -176,9 +221,12 @@ function postprocess(messages) {
     }
 
     function translate(block, message) {
+        var line = block.rawText.split("\n")[message.line - 1],
+            indent = new RegExp("^ {0," + block.indent.length + "}").exec(line);
+
         return assign({}, message, {
             line: message.line + block.loc.start.line,
-            column: message.column + block.loc.start.column
+            column: message.column + indent[0].length
         });
     }
 


### PR DESCRIPTION
http://spec.commonmark.org/0.21/#fenced-code-blocks

- Anything indented >4 spaces is considered an indented code block
- Code fences may be indented by 0 to 3 spaces
- Lines are unindented up to the level of the opening fence
- Fences may have backticks (`) or tildes (~)
- Fences may consist of >= 3 characters
- Closing fences must be at least as long as the opening fence
- Opening fence info strings may contain everything except backticks
- Whitespace around opening fence info strings is ignored
- Closing fences may be followed by whitespace but nothing else

@IanVS how's this?