### PR TITLE
Upgrade: ESLint v1

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,28 +1,102 @@
-{
-  "plugins": [
-    "markdown"
-  ],
-  "env": {
-    "node": true
-  },
-  "rules": {
-    "indent": 2,
-    "brace-style": [2, "1tbs"],
-    "camelcase": [2, { "properties": "never" }],
-    "comma-style": [2, "last"],
-    "default-case": 2,
-    "func-style": [2, "declaration"],
-    "guard-for-in": 2,
-    "no-floating-decimal": 2,
-    "no-nested-ternary": 2,
-    "no-undefined": 2,
-    "radix": 2,
-    "space-after-function-name": [2, "never"],
-    "space-after-keywords": [2, "always"],
-    "space-before-blocks": 2,
-    "spaced-line-comment": [2, "always", { "exceptions": ["-"] }],
-    "strict": 0,
-    "valid-jsdoc": [2, { "prefer": { "return": "returns" }}],
-    "wrap-iife": 2
-  }
-}
+root: true
+
+plugins:
+  - "markdown"
+
+env:
+    node: true
+
+extends:
+    "eslint:recommended"
+
+rules:
+    indent: [2, 4, {SwitchCase: 1}]
+    block-spacing: 2
+    brace-style: [2, "1tbs"]
+    camelcase: [2, { properties: "never" }]
+    callback-return: [2, ["cb", "callback", "next"]]
+    comma-spacing: 2
+    comma-style: [2, "last"]
+    consistent-return: 2
+    curly: [2, "all"]
+    default-case: 2
+    dot-notation: [2, { allowKeywords: true }]
+    eol-last: 2
+    eqeqeq: 2
+    func-style: [2, "declaration"]
+    guard-for-in: 2
+    key-spacing: [2, { beforeColon: false, afterColon: true }]
+    new-cap: 2
+    new-parens: 2
+    no-alert: 2
+    no-array-constructor: 2
+    no-caller: 2
+    no-console: 0
+    no-delete-var: 2
+    no-empty-label: 2
+    no-eval: 2
+    no-extend-native: 2
+    no-extra-bind: 2
+    no-fallthrough: 2
+    no-floating-decimal: 2
+    no-implied-eval: 2
+    no-invalid-this: 2
+    no-iterator: 2
+    no-label-var: 2
+    no-labels: 2
+    no-lone-blocks: 2
+    no-loop-func: 2
+    no-mixed-spaces-and-tabs: [2, false]
+    no-multi-spaces: 2
+    no-multi-str: 2
+    no-native-reassign: 2
+    no-nested-ternary: 2
+    no-new: 2
+    no-new-func: 2
+    no-new-object: 2
+    no-new-wrappers: 2
+    no-octal: 2
+    no-octal-escape: 2
+    no-process-exit: 2
+    no-proto: 2
+    no-redeclare: 2
+    no-return-assign: 2
+    no-script-url: 2
+    no-sequences: 2
+    no-shadow: 2
+    no-shadow-restricted-names: 2
+    no-spaced-func: 2
+    no-trailing-spaces: 2
+    no-undef: 2
+    no-undef-init: 2
+    no-undefined: 2
+    no-underscore-dangle: 2
+    no-unused-expressions: 2
+    no-unused-vars: [2, {vars: "all", args: "after-used"}]
+    no-use-before-define: 2
+    no-with: 2
+    quotes: [2, "double"]
+    radix: 2
+    semi: 2
+    semi-spacing: [2, {before: false, after: true}]
+    space-after-keywords: [2, "always"]
+    space-before-blocks: 2
+    space-before-function-paren: [2, "never"]
+    space-infix-ops: 2
+    space-return-throw-case: 2
+    space-unary-ops: [2, {words: true, nonwords: false}]
+    spaced-comment: [2, "always", { exceptions: ["-"]}]
+    strict: [2, "global"]
+    valid-jsdoc: [2, { prefer: { "return": "returns"}}]
+    wrap-iife: 2
+    yoda: [2, "never"]
+
+    # Previously on by default in node environment
+    no-catch-shadow: 0
+    no-console: 0
+    no-mixed-requires: 2
+    no-new-require: 2
+    no-path-concat: 2
+    no-process-exit: 2
+    global-strict: [0, "always"]
+    handle-callback-err: [2, "err"]

--- a/index.js
+++ b/index.js
@@ -1,1 +1,3 @@
+"use strict";
+
 module.exports = require("./lib");

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,10 +3,10 @@
 var processor = require("./processor");
 
 module.exports = {
-	"processors": {
-		".markdown": processor,
-		".mdown": processor,
-		".mkdn": processor,
-		".md": processor
-	}
+    "processors": {
+        ".markdown": processor,
+        ".mdown": processor,
+        ".mkdn": processor,
+        ".md": processor
+    }
 };

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -208,11 +208,11 @@ function postprocess(messages) {
 
     /**
      * Returns messages which are not in the list of expected errors
-     * @param  {Message[]}  msgs A flattened array of messages with mapped locations.
-     * @returns {Message[]}      An array of messages without expected messages.
+     * @param {Message[]} msgs A flattened array of messages with mapped locations.
+     * @returns {Message[]} An array of messages without expected messages.
      */
     function getUnexpectedMessages(msgs) {
-        return msgs.filter(function (error) {
+        return msgs.filter(function(error) {
             if (!expectedErrors[error.line]) {
                 return true;
             }
@@ -220,6 +220,13 @@ function postprocess(messages) {
         });
     }
 
+    /**
+     * Translate a block's error messages to the correct locations in the
+     * original Markdown source.
+     * @param {object} block The fenced code block being tracked.
+     * @param {Message} message The error message reported by ESLint.
+     * @returns {Message} A copy of the message with translated location info.
+     */
     function translate(block, message) {
         var line = block.rawText.split("\n")[message.line - 1],
             indent = new RegExp("^ {0," + block.indent.length + "}").exec(line);

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "chai": "^3.0.0",
-    "eslint": "^0.24.0",
+    "eslint": "^1.2.1",
     "mocha": "^2.2.5"
   },
   "dependencies": {

--- a/test/processor.js
+++ b/test/processor.js
@@ -397,7 +397,7 @@ describe("processor", function() {
         });
     });
 
-    describe("expected error messages", function () {
+    describe("expected error messages", function() {
         var code,
             messages;
 


### PR DESCRIPTION
This copies the `.eslintrc` from `eslint@1.2.1` with the only addition being this plugin itself.

@nzakas are there any more code style differences that this doesn't fix yet?