### PR TITLE
Update: Allow line comments for expected errors (fixes #12)

### DIFF
--- a/lib/processor.js
+++ b/lib/processor.js
@@ -31,9 +31,11 @@ function parse(text) {
         mode = modes.NORMAL,
         next,
         expErr,
-        expErrQty;
+        expErrQty,
+        currentLineText;
 
-    var EXP_ERR_REGEX = /\/\*\s*error\s+(.+?)\s*\*\//g,
+    var EXP_ERR_BLOCK_REGEX = /\/\*\s*error\s+(.+?)\s*\*\//g,
+        EXP_ERR_LINE_REGEX = /\/\/\s*error\s+(.+)/g,
         EXP_ERR_QTY_REGEX = /\/\/\s*(\d+) errors$/;
 
     /**
@@ -145,6 +147,8 @@ function parse(text) {
 
     while (index < text.length) {
 
+        currentLineText = text.slice(index).split("\n")[0];
+
         // Newline
         if (match(/^\r?\n/)) {
             line += 1;
@@ -173,7 +177,8 @@ function parse(text) {
         // Capture expected errors
         while (
             mode === modes.CODE &&
-            (expErr = EXP_ERR_REGEX.exec(text.slice(index).split("\n")[0])) !== null
+            ((expErr = EXP_ERR_BLOCK_REGEX.exec(currentLineText)) !== null ||
+            (expErr = EXP_ERR_LINE_REGEX.exec(currentLineText)) !== null)
         ) {
             expectedErrors[line + 1] = expectedErrors[line + 1] || [];
             expectedErrors[line + 1].push(expErr[1]);

--- a/test/processor.js
+++ b/test/processor.js
@@ -438,11 +438,13 @@ describe("processor", function() {
                 "",
                 "```js",
                 "foo = 2; /*  error \"foo\" is not defined.*/",
+                "bar = 42;  //  error \"bar\" is not defined.",
                 "```"
             ].join("\n");
             messages = [
                 [
-                    { line: 1, column: 0, message: "\"foo\" is not defined." }
+                    { line: 1, column: 0, message: "\"foo\" is not defined." },
+                    { line: 2, column: 0, message: "\"bar\" is not defined." }
                 ]
             ];
 
@@ -527,6 +529,26 @@ describe("processor", function() {
                 [
                     { line: 1, column: 0, message: "\"foo\" is not defined." },
                     { line: 1, column: 0, message: "Unnecessary semicolon." }
+                ]
+            ];
+
+            processor.preprocess(code);
+            var result = processor.postprocess(messages);
+
+            assert.equal(result.length, 0);
+        });
+
+        it("should be able to be provided as a line comment", function() {
+            code = [
+                "Here's some code:",
+                "",
+                "```js",
+                "foo = 2; //error \"foo\" is not defined.",
+                "```"
+            ].join("\n");
+            messages = [
+                [
+                    { line: 1, column: 0, message: "\"foo\" is not defined." }
                 ]
             ];
 


### PR DESCRIPTION
Allows expected errors to be provided as line comments, as well as block comments.

@btmills, I'm not particularly happy with the regex, but it does seem to work.  Can you please review?