### PR TITLE
Update: Optimize expected error checking (fixes #16)

### DIFF
--- a/lib/processor.js
+++ b/lib/processor.js
@@ -30,9 +30,7 @@ function parse(text) {
         column = 0,
         mode = modes.NORMAL,
         next,
-        expErr,
-        expErrQty,
-        currentLineText;
+        err;
 
     var EXP_ERR_BLOCK_REGEX = /\/\*\s*error\s+(.+?)\s*\*\//g,
         EXP_ERR_LINE_REGEX = /\/\/\s*error\s+(.+)/g,
@@ -147,8 +145,6 @@ function parse(text) {
 
     while (index < text.length) {
 
-        currentLineText = text.slice(index).split("\n")[0];
-
         // Newline
         if (match(/^\r?\n/)) {
             line += 1;
@@ -170,23 +166,26 @@ function parse(text) {
 
         // Line content
         } else {
-            next = match(/[^\r\n]*/);
+            next = match(/^[^\r\n]*/);
             column += next[0].length;
-        }
 
-        // Capture expected errors
-        while (
-            mode === modes.CODE &&
-            ((expErr = EXP_ERR_BLOCK_REGEX.exec(currentLineText)) !== null ||
-            (expErr = EXP_ERR_LINE_REGEX.exec(currentLineText)) !== null)
-        ) {
-            expectedErrors[line + 1] = expectedErrors[line + 1] || [];
-            expectedErrors[line + 1].push(expErr[1]);
-        }
+            // Capture expected errors
+            if (mode === modes.CODE) {
 
-        // Capture number of expected errors
-        if (mode === modes.CODE && (expErrQty = EXP_ERR_QTY_REGEX.exec(text.slice(index).split("\n")[0])) !== null) {
-            expectedErrorQtys[line + 1] = +expErrQty[1];
+                // By exact message
+                while (
+                    (err = EXP_ERR_BLOCK_REGEX.exec(next)) ||
+                    (err = EXP_ERR_LINE_REGEX.exec(next))
+                ) {
+                    expectedErrors[line + 1] = expectedErrors[line + 1] || [];
+                    expectedErrors[line + 1].push(err[1]);
+                }
+
+                // By number of expected errors
+                if ((err = EXP_ERR_QTY_REGEX.exec(next))) {
+                    expectedErrorQtys[line + 1] = +err[1];
+                }
+            }
         }
     }
 


### PR DESCRIPTION
I realized we already had the text of the current line, so there was no need to regenerate it with the `split()`. Now the error checking only runs when a line of code is found, and it only checks mode once.