### PR TITLE
Upgrade: Dependencies (fixes #40)

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,16 +26,13 @@
     "test": "eslint --ext .js --ext .md . && mocha tests"
   },
   "main": "index.js",
-  "peerDependencies": {
-    "eslint": ">=0.16.0"
-  },
   "devDependencies": {
     "chai": "^3.0.0",
-    "eslint": "^1.10.3",
-    "eslint-config-eslint": "^1.0.1",
+    "eslint": "^2.0.0-beta.1",
+    "eslint-config-eslint": "^2.0.0",
     "mocha": "^2.2.5"
   },
   "dependencies": {
-    "object-assign": "^3.0.0"
+    "object-assign": "^4.0.1"
   }
 }


### PR DESCRIPTION
This will pull in the changes to `eslint-config-eslint` from eslint/eslint#4910, which requires `eslint@2`. Updated `object-assign` as well to clean up `npm outdated` output.