### PR TITLE
Update: Support configuration comments (fixes #46, fixes #54)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,39 @@ Blocks that don't specify either `js`, `javascript`, `jsx`, or `node` syntax are
     print("This doesn't get linted either.")
     ```
 
+## Configuration Comments
+
+The processor will convert HTML comments immediately preceding a code block into JavaScript block comments and insert them at the beginning of the source code that it passes to ESLint. This permits configuring ESLint via configuration comments while keeping the configuration comments themselves hidden when the markdown is rendered. Comment bodies are passed through unmodified, so the plugin supports any [configuration comments](http://eslint.org/docs/user-guide/configuring) supported by ESLint itself.
+
+This example enables the `browser` environment, disables the `no-alert` rule, and configures the `quotes` rule to prefer single quotes:
+
+    <!-- eslint-env browser -->
+    <!-- eslint-disable no-alert -->
+    <!-- eslint quotes: ["error", "single"] -->
+
+    ```js
+    alert('Hello, world!');
+    ```
+
+Each code block in a file is linted separately, so configuration comments apply only to the code block that immediately follows.
+
+    Assuming `no-alert` is enabled in `.eslintrc`, the first code block will have no error from `no-alert`:
+
+    <!-- eslint-env browser -->
+    <!-- eslint-disable no-alert -->
+
+    ```js
+    alert("Hello, world!");
+    ```
+
+    But the next code block will have an error from `no-alert`:
+
+    <!-- eslint-env browser -->
+
+    ```js
+    alert("Hello, world!");
+    ```
+
 ## Unsatisfiable Rules
 
 Since code blocks are not files themselves but embedded inside a Markdown document, some rules do not apply to Markdown code blocks, and messages from these rules are automatically suppressed:

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -6,6 +6,7 @@
 "use strict";
 
 var assign = require("object-assign");
+var parse5 = require("parse5");
 var remark = require("remark");
 
 var SUPPORTED_SYNTAXES = ["js", "javascript", "node", "jsx"];
@@ -19,42 +20,107 @@ var blocks = [];
  * Performs a depth-first traversal of the Markdown AST.
  * @param {ASTNode} node A Markdown AST node.
  * @param {object} callbacks A map of node types to callbacks.
+ * @param {object} [parent] The node's parent AST node.
  * @returns {void}
  */
-function traverse(node, callbacks) {
+function traverse(node, callbacks, parent) {
     var i;
 
     if (callbacks[node.type]) {
-        callbacks[node.type](node);
+        callbacks[node.type](node, parent);
     }
 
     if (typeof node.children !== "undefined") {
         for (i = 0; i < node.children.length; i++) {
-            traverse(node.children[i], callbacks);
+            traverse(node.children[i], callbacks, node);
         }
     }
 }
 
 /**
+ * Converts leading HTML comments to JS block comments.
+ * @param {string} html The text content of an HTML AST node.
+ * @returns {string[]} An array of JS block comments.
+ */
+function getComments(html) {
+    var ast = parse5.parse(html, { locationInfo: true });
+    var nodes = ast.childNodes.filter(function(node) {
+        return node.__location; // eslint-disable-line no-underscore-dangle
+    });
+    var comments = [];
+    var index;
+
+    for (index = nodes.length - 1; index >= 0; index--) {
+        if (
+            nodes[index].nodeName === "#comment"
+            && nodes[index].data.trim().slice(0, "eslint".length) === "eslint"
+        ) {
+            comments.unshift("/*" + nodes[index].data + "*/");
+        } else {
+            break;
+        }
+    }
+
+    return comments;
+}
+
+/**
  * Extracts lintable JavaScript code blocks from Markdown text.
  * @param {string} text The text of the file.
- * @returns {[string]} Code blocks to lint.
+ * @returns {string[]} Source code strings to lint.
  */
 function preprocess(text) {
     var ast = remark.parse(text);
 
     blocks = [];
     traverse(ast, {
-        "code": function(node) {
+        "code": function(node, parent) {
+            var comments = [];
+            var index, previousNode;
+
             if (node.lang && SUPPORTED_SYNTAXES.indexOf(node.lang.toLowerCase()) >= 0) {
-                blocks.push(node);
+                index = parent.children.indexOf(node);
+                previousNode = parent.children[index - 1];
+                if (previousNode && previousNode.type === "html") {
+                    comments = getComments(previousNode.value) || [];
+                }
+
+                blocks.push(assign({}, node, { comments: comments }));
             }
         }
     });
 
     return blocks.map(function(block) {
-        return block.value;
+        return block.comments.concat(block.value).join("\n");
     });
+}
+
+/**
+ * Creates a map function that adjusts messages in a code block.
+ * @param {Block} block A code block.
+ * @returns {function} A function that adjusts messages in a code block.
+ */
+function adjustBlock(block) {
+    var leadingCommentLines = block.comments.reduce(function(count, comment) {
+        return count + comment.split("\n").length;
+    }, 0);
+
+    /**
+     * Adjusts ESLint messages to point to the correct location in the Markdown.
+     * @param {Message} message A message from ESLint.
+     * @returns {Message} The same message, but adjusted ot the correct location.
+     */
+    return function adjustMessage(message) {
+        var lineInCode = message.line - leadingCommentLines;
+        if (lineInCode < 1) {
+            return null;
+        }
+
+        return assign({}, message, {
+            line: lineInCode + block.position.start.line,
+            column: message.column + block.position.indent[lineInCode - 1] - 1
+        });
+    };
 }
 
 /**
@@ -63,7 +129,7 @@ function preprocess(text) {
  * @returns {boolean} True if the message should be included in output.
  */
 function excludeUnsatisfiableRules(message) {
-    return UNSATISFIABLE_RULES.indexOf(message.ruleId) < 0;
+    return message && UNSATISFIABLE_RULES.indexOf(message.ruleId) < 0;
 }
 
 /**
@@ -74,12 +140,8 @@ function excludeUnsatisfiableRules(message) {
  */
 function postprocess(messages) {
     return [].concat.apply([], messages.map(function(group, i) {
-        return group.filter(excludeUnsatisfiableRules).map(function(message) {
-            return assign({}, message, {
-                line: message.line + blocks[i].position.start.line,
-                column: message.column + blocks[i].position.indent[message.line - 1] - 1
-            });
-        });
+        var adjust = adjustBlock(blocks[i]);
+        return group.map(adjust).filter(excludeUnsatisfiableRules);
     }));
 }
 

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   },
   "dependencies": {
     "object-assign": "^4.0.1",
+    "parse5": "^2.2.2",
     "remark": "^4.1.1"
   }
 }

--- a/tests/fixtures/long.md
+++ b/tests/fixtures/long.md
@@ -17,16 +17,33 @@ function foo() {
 }
 ```
 
+<!-- eslint-env node -->
+<!-- eslint-disable eol-last, quotes -->
+
 ```node
 console.log(process.version);
 ```
 
 How about some JSX?
 
+<!--
+    eslint quotes: [
+        "error",
+        "single"
+    ]
+-->
+<!--eslint-disable no-console-->
+
 ```jsx
 console.log("Error!");
 ```
 
     I may be a code block, but don't lint me!
+
+<!-- eslint-disable -->
+
+```js
+!@#$%^&*()
+```
 
 The end.

--- a/tests/plugin.js
+++ b/tests/plugin.js
@@ -21,11 +21,15 @@ describe("plugin", function() {
 
     before(function() {
         cli = new CLIEngine({
+            envs: ["browser"],
             extensions: ["md", "mkdn", "mdown", "markdown"],
             ignore: false,
             rules: {
                 "eol-last": 2,
-                "no-console": 2
+                "no-console": 2,
+                "no-undef": 2,
+                "quotes": 2,
+                "spaced-comment": 2
             },
             useEslintrc: false
         });
@@ -72,16 +76,26 @@ describe("plugin", function() {
         var report = cli.executeOnFiles([path.resolve(__dirname, "fixtures/long.md")]);
 
         assert.equal(report.results.length, 1);
-        assert.equal(report.results[0].messages.length, 4);
+        assert.equal(report.results[0].messages.length, 5);
         assert.equal(report.results[0].messages[0].message, "Unexpected console statement.");
         assert.equal(report.results[0].messages[0].line, 10);
+        assert.equal(report.results[0].messages[0].column, 1);
         assert.equal(report.results[0].messages[1].message, "Unexpected console statement.");
         assert.equal(report.results[0].messages[1].line, 16);
         assert.equal(report.results[0].messages[1].column, 5);
         assert.equal(report.results[0].messages[2].message, "Unexpected console statement.");
-        assert.equal(report.results[0].messages[2].line, 21);
-        assert.equal(report.results[0].messages[3].message, "Unexpected console statement.");
-        assert.equal(report.results[0].messages[3].line, 27);
+        assert.equal(report.results[0].messages[2].line, 24);
+        assert.equal(report.results[0].messages[2].column, 1);
+        assert.equal(report.results[0].messages[3].message, "Strings must use singlequote.");
+        assert.equal(report.results[0].messages[3].line, 38);
+        assert.equal(report.results[0].messages[3].column, 13);
+        assert.equal(report.results[0].messages[4].message, "Parsing error: Unexpected character '@'");
+        assert.equal(report.results[0].messages[4].line, 46);
+        assert.equal(report.results[0].messages[4].column, 2);
+    });
+
+    describe("disable comments", function() {
+
     });
 
 });

--- a/tests/processor.js
+++ b/tests/processor.js
@@ -326,6 +326,35 @@ describe("processor", function() {
             assert.equal(blocks[1], "console.log(answer);");
         });
 
+        it("should insert leading configuration comments", function() {
+            var code = [
+                "<!-- eslint-env browser -->",
+                "<!--",
+                "    eslint quotes: [",
+                "        \"error\",",
+                "        \"single\"",
+                "    ]",
+                "-->",
+                "",
+                "```js",
+                "alert('Hello, world!');",
+                "```"
+            ].join("\n");
+            var blocks = processor.preprocess(code);
+
+            assert.equal(blocks.length, 1);
+            assert.equal(blocks[0], [
+                "/* eslint-env browser */",
+                "/*",
+                "    eslint quotes: [",
+                "        \"error\",",
+                "        \"single\"",
+                "    ]",
+                "*/",
+                "alert('Hello, world!');"
+            ].join("\n"));
+        });
+
     });
 
     describe("postprocess", function() {


### PR DESCRIPTION
Initially, #46 was about adding custom syntax and logic into the processor to support configuration comments. The plugin would permit disabling ESLint or specific rules for entire code blocks, and all of that would be done in the plugin. Eventually, #54 would support configuring rule options.

I realized while working on #46 that custom syntax is unnecessary and overly complex when ESLint already has built-in support for configuration comments! With this change, when the plugin sees an HTML comment preceding a code block, it converts the comment's body into a JS block comment at the beginning of the source code. If it's an ESLint config comment, ESLint will pick up on it.

This example enables the browser environment, disables the no-alert rule, and configures the quotes rule to prefer single quotes:

    <!-- eslint-env browser -->
    <!-- eslint-disable no-alert -->
    <!-- eslint quotes: ["error", "single"] -->

    ```js
    alert('Hello, world!');
    ```

Internally, the generated code that gets passed to ESLint looks like this:

```js
/* eslint-env browser */
/* eslint-disable no-alert */
/* eslint quotes: ["error", "single"] */
alert('Hello, world!');
```