### PR TITLE
Build: Explicitly specify package.json files

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,10 +34,9 @@
   },
   "main": "index.js",
   "files": [
-    "lib/*.js",
     "index.js",
-    "LICENSE",
-    "README.md"
+    "lib/index.js",
+    "lib/processor.js"
   ],
   "devDependencies": {
     "chai": "^3.0.0",


### PR DESCRIPTION
`eslint-release` expects `pkg.files` to be an array of relative paths without any globs.

`lib/.eslintrc.yml` shouldn't be included in the bundle, so it's necessary to specify individual paths instead of just `lib`.