### PR TITLE
Chore: Un-disable strict and eol-last in repository

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,10 +22,5 @@ module.exports = {
         "node": true
     },
 
-    "extends": "eslint",
-
-    "rules": {
-        "strict": "off",
-        "eol-last": "off"
-    }
+    "extends": "eslint"
 };

--- a/lib/.eslintrc.yml
+++ b/lib/.eslintrc.yml
@@ -1,3 +1,0 @@
-rules:
-    eol-last: 2
-    strict: [2, "global"]

--- a/tests/.eslintrc.yml
+++ b/tests/.eslintrc.yml
@@ -1,6 +1,2 @@
 env:
     mocha: true
-
-rules:
-    eol-last: 2
-    strict: [2, "global"]


### PR DESCRIPTION
These rules were originally disabled when the README contained JS code fences that were getting linted. That's no longer the case, so we don't need to override `eslint-config-eslint` anymore.