### PR TITLE
New: Custom eslint-skip HTML comment skips blocks (fixes #69)

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,26 @@ Each code block in a file is linted separately, so configuration comments apply 
     alert("Hello, world!");
     ```
 
+## Skipping Blocks
+
+Sometimes it can be useful to have code blocks marked with `js` even though they don't contain valid JavaScript syntax, such as commented JSON blobs that need `js` syntax highlighting. Standard `eslint-disable` comments only silence rule reporting, but ESLint still reports any syntax errors it finds. In cases where a code block should not even be parsed, insert a non-standard `<!-- eslint-skip -->` comment before the block, and this plugin will hide the following block from ESLint. Neither rule nor syntax errors will be reported.
+
+    There are comments in this JSON, so we use `js` syntax for better
+    highlighting. Skip the block to prevent warnings about invalid syntax.
+
+    <!-- eslint-skip -->
+
+    ```js
+    {
+        // This code block is hidden from ESLint.
+        "hello": "world"
+    }
+    ```
+
+    ```js
+    console.log("This code block is linted normally.");
+    ```
+
 ## Unsatisfiable Rules
 
 Since code blocks are not files themselves but embedded inside a Markdown document, some rules do not apply to Markdown code blocks, and messages from these rules are automatically suppressed:

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -62,7 +62,7 @@ function getComment(html) {
         return "";
     }
 
-    return "/*" + html + "*/";
+    return html;
 }
 
 /**
@@ -88,7 +88,12 @@ function preprocess(text) {
                     if (!comment) {
                         break;
                     }
-                    comments.unshift(comment);
+
+                    if (comment.trim() === "eslint-skip") {
+                        return;
+                    }
+
+                    comments.unshift("/*" + comment + "*/");
                     index--;
                     previousNode = parent.children[index];
                 }

--- a/tests/lib/processor.js
+++ b/tests/lib/processor.js
@@ -405,6 +405,61 @@ describe("processor", function() {
             ].join("\n"));
         });
 
+        describe("eslint-skip", function() {
+
+            it("should skip the next block", function() {
+                var code = [
+                    "<!-- eslint-skip -->",
+                    "",
+                    "```js",
+                    "alert('Hello, world!');",
+                    "```"
+                ].join("\n");
+                var blocks = processor.preprocess(code);
+
+                assert.equal(blocks.length, 0);
+            });
+
+            it("should skip only one block", function() {
+                var code = [
+                    "<!-- eslint-skip -->",
+                    "",
+                    "```js",
+                    "alert('Hello, world!');",
+                    "```",
+                    "",
+                    "```js",
+                    "var answer = 6 * 7;",
+                    "```"
+                ].join("\n");
+                var blocks = processor.preprocess(code);
+
+                assert.equal(blocks.length, 1);
+                assert.equal(blocks[0], "var answer = 6 * 7;");
+            });
+
+            it("should still work surrounded by other comments", function() {
+                var code = [
+                    "<!-- eslint-disable no-console -->",
+                    "<!-- eslint-skip -->",
+                    "<!-- eslint-disable quotes -->",
+                    "",
+                    "```js",
+                    "alert('Hello, world!');",
+                    "```",
+                    "",
+                    "```js",
+                    "var answer = 6 * 7;",
+                    "```"
+                ].join("\n");
+                var blocks = processor.preprocess(code);
+
+                assert.equal(blocks.length, 1);
+                assert.equal(blocks[0], "var answer = 6 * 7;");
+            });
+
+        });
+
     });
 
     describe("postprocess", function() {


### PR DESCRIPTION
    <!-- eslint-skip -->

    ```js
    {
        // This code block is hidden from ESLint.
        "hello": "world"
    }
    ```

    ```js
    console.log("This code block is linted normally.");
    ```
