### PR TITLE
Fix: Emit correct endLine numbers

### DIFF
--- a/lib/processor.js
+++ b/lib/processor.js
@@ -136,7 +136,7 @@ function adjustBlock(block) {
 
         return assign({}, message, {
             line: lineInCode + blockStart,
-            endLine: endLine ? message.endLine + blockStart : endLine,
+            endLine: endLine ? message.endLine + blockStart - 1 : endLine,
             column: message.column + block.position.indent[lineInCode - 1] - 1
         });
     };

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -134,11 +134,13 @@ function adjustBlock(block) {
             return null;
         }
 
-        return assign({}, message, {
+        var out = {
             line: lineInCode + blockStart,
-            endLine: endLine ? message.endLine + blockStart - 1 : endLine,
+            endLine: endLine ? endLine + blockStart : endLine,
             column: message.column + block.position.indent[lineInCode - 1] - 1
-        });
+        };
+
+        return assign({}, message, out);
     };
 }
 

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -119,19 +119,24 @@ function adjustBlock(block) {
         return count + comment.split("\n").length;
     }, 0);
 
+    var blockStart = block.position.start.line;
+
     /**
      * Adjusts ESLint messages to point to the correct location in the Markdown.
      * @param {Message} message A message from ESLint.
      * @returns {Message} The same message, but adjusted ot the correct location.
      */
     return function adjustMessage(message) {
+
         var lineInCode = message.line - leadingCommentLines;
+        var endLine = message.endLine;
         if (lineInCode < 1) {
             return null;
         }
 
         return assign({}, message, {
-            line: lineInCode + block.position.start.line,
+            line: lineInCode + blockStart,
+            endLine: endLine ? message.endLine + blockStart : endLine,
             column: message.column + block.position.indent[lineInCode - 1] - 1
         });
     };

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -129,7 +129,7 @@ function adjustBlock(block) {
     return function adjustMessage(message) {
 
         var lineInCode = message.line - leadingCommentLines;
-        var endLine = message.endLine;
+        var endLine = message.endLine - leadingCommentLines;
         if (lineInCode < 1) {
             return null;
         }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   ],
   "devDependencies": {
     "chai": "^3.0.0",
-    "eslint": "4",
+    "eslint": "^2.2.0",
     "eslint-config-eslint": "^3.0.0",
     "eslint-release": "^0.10.2",
     "istanbul": "^0.4.5",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   ],
   "devDependencies": {
     "chai": "^3.0.0",
-    "eslint": "^2.2.0",
+    "eslint": "4",
     "eslint-config-eslint": "^3.0.0",
     "eslint-release": "^0.10.2",
     "istanbul": "^0.4.5",

--- a/tests/lib/plugin.js
+++ b/tests/lib/plugin.js
@@ -60,10 +60,33 @@ describe("plugin", function() {
         var report = cli.executeOnText(code, "test.md");
         assert.equal(report.results[0].messages[0].message, "'baz' is not defined.");
         assert.equal(report.results[0].messages[0].line, 5);
-        assert.equal(report.results[0].messages[0].endLine, 5);
+        assert.equal(report.results[0].messages[0].endLine, 4);
         assert.equal(report.results[0].messages[1].message, "'blah' is not defined.");
         assert.equal(report.results[0].messages[1].line, 8);
-        assert.equal(report.results[0].messages[1].endLine, 8);
+        assert.equal(report.results[0].messages[1].endLine, 7);
+    });
+
+    it("should emit correct line numbers with leading comments", function() {
+        var code = [
+            "# Hello, world!",
+            "",
+            "<!-- eslint-disable quotes -->",
+            "",
+            "```js",
+            "var bar = baz",
+            "",
+            "var str = 'single quotes'",
+            "",
+            "var foo = blah",
+            "```"
+        ].join("\n");
+        var report = cli.executeOnText(code, "test.md");
+        assert.equal(report.results[0].messages[0].message, "'baz' is not defined.");
+        assert.equal(report.results[0].messages[0].line, 6);
+        assert.equal(report.results[0].messages[0].endLine, 6);
+        assert.equal(report.results[0].messages[1].message, "'blah' is not defined.");
+        assert.equal(report.results[0].messages[1].line, 10);
+        assert.equal(report.results[0].messages[1].endLine, 10);
     });
 
     it("should run on .mkdn files", function() {

--- a/tests/lib/plugin.js
+++ b/tests/lib/plugin.js
@@ -45,6 +45,27 @@ describe("plugin", function() {
         assert.equal(report.results[0].messages[0].line, 2);
     });
 
+    it("should emit correct line numbers", function() {
+        var code = [
+            "# Hello, world!",
+            "",
+            "",
+            "```js",
+            "var bar = baz",
+            "",
+            "",
+            "var foo = blah",
+            "```"
+        ].join("\n");
+        var report = cli.executeOnText(code, "test.md");
+        assert.equal(report.results[0].messages[0].message, "'baz' is not defined.");
+        assert.equal(report.results[0].messages[0].line, 5);
+        assert.equal(report.results[0].messages[0].endLine, 5);
+        assert.equal(report.results[0].messages[1].message, "'blah' is not defined.");
+        assert.equal(report.results[0].messages[1].line, 8);
+        assert.equal(report.results[0].messages[1].endLine, 8);
+    });
+
     it("should run on .mkdn files", function() {
         var report = cli.executeOnText(shortText, "test.mkdn");
 

--- a/tests/lib/plugin.js
+++ b/tests/lib/plugin.js
@@ -60,10 +60,10 @@ describe("plugin", function() {
         var report = cli.executeOnText(code, "test.md");
         assert.equal(report.results[0].messages[0].message, "'baz' is not defined.");
         assert.equal(report.results[0].messages[0].line, 5);
-        assert.equal(report.results[0].messages[0].endLine, 4);
+        assert.equal(report.results[0].messages[0].endLine, 5);
         assert.equal(report.results[0].messages[1].message, "'blah' is not defined.");
         assert.equal(report.results[0].messages[1].line, 8);
-        assert.equal(report.results[0].messages[1].endLine, 7);
+        assert.equal(report.results[0].messages[1].endLine, 8);
     });
 
     it("should emit correct line numbers with leading comments", function() {
@@ -71,6 +71,7 @@ describe("plugin", function() {
             "# Hello, world!",
             "",
             "<!-- eslint-disable quotes -->",
+            "<!-- eslint-disable semi -->",
             "",
             "```js",
             "var bar = baz",
@@ -82,11 +83,11 @@ describe("plugin", function() {
         ].join("\n");
         var report = cli.executeOnText(code, "test.md");
         assert.equal(report.results[0].messages[0].message, "'baz' is not defined.");
-        assert.equal(report.results[0].messages[0].line, 6);
-        assert.equal(report.results[0].messages[0].endLine, 6);
+        assert.equal(report.results[0].messages[0].line, 7);
+        assert.equal(report.results[0].messages[0].endLine, 7);
         assert.equal(report.results[0].messages[1].message, "'blah' is not defined.");
-        assert.equal(report.results[0].messages[1].line, 10);
-        assert.equal(report.results[0].messages[1].endLine, 10);
+        assert.equal(report.results[0].messages[1].line, 11);
+        assert.equal(report.results[0].messages[1].endLine, 11);
     });
 
     it("should run on .mkdn files", function() {

--- a/tests/lib/plugin.js
+++ b/tests/lib/plugin.js
@@ -45,7 +45,7 @@ describe("plugin", function() {
         assert.equal(report.results[0].messages[0].line, 2);
     });
 
-    it("should emit correct line numbers", function() {
+    it.skip("should emit correct line numbers", function() {
         var code = [
             "# Hello, world!",
             "",
@@ -66,7 +66,7 @@ describe("plugin", function() {
         assert.equal(report.results[0].messages[1].endLine, 8);
     });
 
-    it("should emit correct line numbers with leading comments", function() {
+    it.skip("should emit correct line numbers with leading comments", function() {
         var code = [
             "# Hello, world!",
             "",

--- a/tests/lib/plugin.js
+++ b/tests/lib/plugin.js
@@ -45,7 +45,7 @@ describe("plugin", function() {
         assert.equal(report.results[0].messages[0].line, 2);
     });
 
-    it.skip("should emit correct line numbers", function() {
+    it("should emit correct line numbers", function() {
         var code = [
             "# Hello, world!",
             "",
@@ -66,7 +66,7 @@ describe("plugin", function() {
         assert.equal(report.results[0].messages[1].endLine, 8);
     });
 
-    it.skip("should emit correct line numbers with leading comments", function() {
+    it("should emit correct line numbers with leading comments", function() {
         var code = [
             "# Hello, world!",
             "",

--- a/tests/lib/processor.js
+++ b/tests/lib/processor.js
@@ -514,13 +514,13 @@ describe("processor", function() {
         ].join("\n");
         var messages = [
             [
-                { line: 1, column: 1, message: "Use the global form of \"use strict\".", ruleId: "strict" },
-                { line: 3, column: 5, message: "Unexpected console statement.", ruleId: "no-console" }
+                { line: 1, endLine: NaN, column: 1, message: "Use the global form of \"use strict\".", ruleId: "strict" },
+                { line: 3, endLine: 3, column: 5, message: "Unexpected console statement.", ruleId: "no-console" }
             ], [
-                { line: 3, column: 6, message: "Missing trailing comma.", ruleId: "comma-dangle" }
+                { line: 3, endLine: 3, column: 6, message: "Missing trailing comma.", ruleId: "comma-dangle" }
             ], [
-                { line: 3, column: 2, message: "Unreachable code after return.", ruleId: "no-unreachable" },
-                { line: 4, column: 2, message: "Unnecessary semicolon.", ruleId: "no-extra-semi" }
+                { line: 3, endLine: 6, column: 2, message: "Unreachable code after return.", ruleId: "no-unreachable" },
+                { line: 4, endLine: 4, column: 2, message: "Unnecessary semicolon.", ruleId: "no-extra-semi" }
             ]
         ];
 
@@ -553,6 +553,16 @@ describe("processor", function() {
             assert.equal(result[2].line, 17);
             assert.equal(result[3].line, 26);
             assert.equal(result[4].line, 27);
+        });
+
+        it("should translate endLine numbers", function() {
+            var result = processor.postprocess(messages);
+
+            assert.isNaN(result[0].endLine);
+            assert.equal(result[1].endLine, 6);
+            assert.equal(result[2].endLine, 17);
+            assert.equal(result[3].endLine, 29);
+            assert.equal(result[4].endLine, 27);
         });
 
         it("should translate column numbers", function() {

--- a/tests/lib/processor.js
+++ b/tests/lib/processor.js
@@ -514,7 +514,7 @@ describe("processor", function() {
         ].join("\n");
         var messages = [
             [
-                { line: 1, endLine: NaN, column: 1, message: "Use the global form of \"use strict\".", ruleId: "strict" },
+                { line: 1, endLine: 1, column: 1, message: "Use the global form of \"use strict\".", ruleId: "strict" },
                 { line: 3, endLine: 3, column: 5, message: "Unexpected console statement.", ruleId: "no-console" }
             ], [
                 { line: 3, endLine: 3, column: 6, message: "Missing trailing comma.", ruleId: "comma-dangle" }
@@ -558,7 +558,7 @@ describe("processor", function() {
         it("should translate endLine numbers", function() {
             var result = processor.postprocess(messages);
 
-            assert.isNaN(result[0].endLine);
+            assert.equal(result[0].endLine, 4);
             assert.equal(result[1].endLine, 6);
             assert.equal(result[2].endLine, 17);
             assert.equal(result[3].endLine, 29);


### PR DESCRIPTION
Fixes #87

This adds each blocks `start.line` to each message's `endLine`, if it exists on the message.

~~This PR also updates the `eslint` used in tests to version 4. The older version of eslint did not emit `endLine` numbers.~~