### PR TITLE
Build: Upgrade to eslint-release@0.11.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "chai": "^3.0.0",
     "eslint": "^2.2.0",
     "eslint-config-eslint": "^3.0.0",
-    "eslint-release": "^0.10.2",
+    "eslint-release": "^0.11.1",
     "istanbul": "^0.4.5",
     "mocha": "^2.2.5"
   },


### PR DESCRIPTION
This brings in @not-an-aardvark's eslint/eslint-release#20 so that release notes get published as a GitHub release.