### PR TITLE
fix: support for eslint-plugin-prettier

### DIFF
--- a/lib/processor.js
+++ b/lib/processor.js
@@ -241,7 +241,7 @@ function preprocess(text) {
     });
 
     return blocks.map(function(block) {
-        return block.comments.concat(block.value).join("\n");
+        return block.comments.concat(block.value).concat("\n").join("\n");
     });
 }
 


### PR DESCRIPTION
For eslint we can disable the end of file line break rule. For prettier that is not possible.

Hence we just append a line break so prettier can pass.

Relevant ticket: #101