### PR TITLE
Chore: Upgrade to eslint-config-eslint@5.0.1

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -5,10 +5,10 @@
 
 "use strict";
 
-var processor = require("./processor");
+const processor = require("./processor");
 
 module.exports = {
-    "processors": {
+    processors: {
         ".markdown": processor,
         ".mdown": processor,
         ".mkdn": processor,

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -226,7 +226,11 @@ function preprocess(text) {
         }
     });
 
-    return blocks.map(block => block.comments.concat(block.value).concat("").join("\n"));
+    return blocks.map(block => [
+        ...block.comments,
+        block.value,
+        ""
+    ].join("\n"));
 }
 
 /**
@@ -301,7 +305,7 @@ function excludeUnsatisfiableRules(message) {
  * @returns {Message[]} A flattened array of messages with mapped locations.
  */
 function postprocess(messages) {
-    return [].concat.apply([], messages.map((group, i) => {
+    return [].concat(...messages.map((group, i) => {
         const adjust = adjustBlock(blocks[i]);
 
         return group.map(adjust).filter(excludeUnsatisfiableRules);

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -28,14 +28,12 @@ let blocks = [];
  * @returns {void}
  */
 function traverse(node, callbacks, parent) {
-    let i;
-
     if (callbacks[node.type]) {
         callbacks[node.type](node, parent);
     }
 
     if (typeof node.children !== "undefined") {
-        for (i = 0; i < node.children.length; i++) {
+        for (let i = 0; i < node.children.length; i++) {
             traverse(node.children[i], callbacks, node);
         }
     }
@@ -58,13 +56,13 @@ function getComment(html) {
         return "";
     }
 
-    html = html.slice(commentStart.length, -commentEnd.length);
+    const comment = html.slice(commentStart.length, -commentEnd.length);
 
-    if (!regex.test(html.trim())) {
+    if (!regex.test(comment.trim())) {
         return "";
     }
 
-    return html;
+    return comment;
 }
 
 const leadingWhitespaceRegex = /^\s*/;
@@ -103,18 +101,6 @@ const leadingWhitespaceRegex = /^\s*/;
  *     returns the corresponding location in the original Markdown source.
  */
 function getBlockRangeMap(text, node, comments) {
-    let baseIndent,
-        code,
-        commentLength,
-        i,
-        jsOffset,
-        leadingWhitespaceLength,
-        line,
-        lines,
-        mdOffset,
-        rangeMap,
-        startOffset,
-        trimLength;
 
     /*
      * The parser sets the fenced code block's start offset to wherever content
@@ -124,14 +110,14 @@ function getBlockRangeMap(text, node, comments) {
      * additional indenting, the opening fence's first backtick may be up to
      * three whitespace characters after the start offset.
      */
-    startOffset = node.position.start.offset;
+    const startOffset = node.position.start.offset;
 
     /*
      * Extract the Markdown source to determine the leading whitespace for each
      * line.
      */
-    code = text.slice(startOffset, node.position.end.offset);
-    lines = code.split("\n");
+    const code = text.slice(startOffset, node.position.end.offset);
+    const lines = code.split("\n");
 
     /*
      * The parser trims leading whitespace from each line of code within the
@@ -139,14 +125,14 @@ function getBlockRangeMap(text, node, comments) {
      * backtick's column is the AST node's starting column plus any additional
      * indentation.
      */
-    baseIndent = node.position.start.column - 1 +
+    const baseIndent = node.position.start.column - 1 +
         leadingWhitespaceRegex.exec(lines[0])[0].length;
 
     /*
      * Track the length of any inserted configuration comments at the beginning
      * of the linted JS and start the JS offset lookup keys at this index.
      */
-    commentLength = comments.reduce((len, comment) => len + comment.length + 1, 0);
+    const commentLength = comments.reduce((len, comment) => len + comment.length + 1, 0);
 
     /*
      * In case there are configuration comments, initialize the map so that the
@@ -154,33 +140,33 @@ function getBlockRangeMap(text, node, comments) {
      * the lookup index will also be 0, and the lookup should always go to the
      * last range that matches, skipping this initialization entry.
      */
-    rangeMap = [{
+    const rangeMap = [{
         js: 0,
         md: 0
     }];
 
     // Start the JS offset after any configuration comments.
-    jsOffset = commentLength;
+    let jsOffset = commentLength;
 
     /*
      * Start the Markdown offset at the beginning of the block's first line of
      * actual code. The first line of the block is always the opening fence, so
      * the code begins on the second line.
      */
-    mdOffset = startOffset + lines[0].length + 1;
+    let mdOffset = startOffset + lines[0].length + 1;
 
     /*
      * For each line, determine how much leading whitespace was trimmed due to
      * indentation. Increase the JS lookup offset by the length of the line
      * post-trimming and the Markdown offset by the total line length.
      */
-    for (i = 0; i + 1 < lines.length; i++) {
-        line = lines[i + 1];
-        leadingWhitespaceLength = leadingWhitespaceRegex.exec(line)[0].length;
+    for (let i = 0; i + 1 < lines.length; i++) {
+        const line = lines[i + 1];
+        const leadingWhitespaceLength = leadingWhitespaceRegex.exec(line)[0].length;
 
         // The parser trims leading whitespace up to the level of the opening
         // fence, so keep any additional indentation beyond that.
-        trimLength = Math.min(baseIndent, leadingWhitespaceLength);
+        const trimLength = Math.min(baseIndent, leadingWhitespaceLength);
 
         rangeMap.push({
             js: jsOffset,
@@ -211,13 +197,13 @@ function preprocess(text) {
     traverse(ast, {
         code(node, parent) {
             const comments = [];
-            let index, previousNode, comment;
 
             if (node.lang && SUPPORTED_SYNTAXES.indexOf(node.lang.split(" ")[0].toLowerCase()) >= 0) {
-                index = parent.children.indexOf(node) - 1;
-                previousNode = parent.children[index];
+                let index = parent.children.indexOf(node) - 1;
+                let previousNode = parent.children[index];
+
                 while (previousNode && previousNode.type === "html") {
-                    comment = getComment(previousNode.value);
+                    const comment = getComment(previousNode.value);
 
                     if (!comment) {
                         break;

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -5,30 +5,30 @@
 
 "use strict";
 
-var assign = require("object-assign");
-var unified = require("unified");
-var remarkParse = require("remark-parse");
+const assign = require("object-assign");
+const unified = require("unified");
+const remarkParse = require("remark-parse");
 
-var SUPPORTED_SYNTAXES = ["js", "javascript", "node", "jsx"];
-var UNSATISFIABLE_RULES = [
+const SUPPORTED_SYNTAXES = ["js", "javascript", "node", "jsx"];
+const UNSATISFIABLE_RULES = [
     "eol-last", // The Markdown parser strips trailing newlines in code fences
     "unicode-bom" // Code blocks will begin in the middle of Markdown files
 ];
-var SUPPORTS_AUTOFIX = true;
+const SUPPORTS_AUTOFIX = true;
 
-var markdown = unified().use(remarkParse);
+const markdown = unified().use(remarkParse);
 
-var blocks = [];
+let blocks = [];
 
 /**
  * Performs a depth-first traversal of the Markdown AST.
  * @param {ASTNode} node A Markdown AST node.
- * @param {object} callbacks A map of node types to callbacks.
- * @param {object} [parent] The node's parent AST node.
+ * @param {Object} callbacks A map of node types to callbacks.
+ * @param {Object} [parent] The node's parent AST node.
  * @returns {void}
  */
 function traverse(node, callbacks, parent) {
-    var i;
+    let i;
 
     if (callbacks[node.type]) {
         callbacks[node.type](node, parent);
@@ -47,9 +47,9 @@ function traverse(node, callbacks, parent) {
  * @returns {string[]} An array of JS block comments.
  */
 function getComment(html) {
-    var commentStart = "<!--";
-    var commentEnd = "-->";
-    var regex = /^(eslint\b|global\s)/;
+    const commentStart = "<!--";
+    const commentEnd = "-->";
+    const regex = /^(eslint\b|global\s)/;
 
     if (
         html.slice(0, commentStart.length) !== commentStart ||
@@ -67,7 +67,7 @@ function getComment(html) {
     return html;
 }
 
-var leadingWhitespaceRegex = /^\s*/;
+const leadingWhitespaceRegex = /^\s*/;
 
 /**
  * When applying fixes, the postprocess step needs to know how to map fix ranges
@@ -97,13 +97,13 @@ var leadingWhitespaceRegex = /^\s*/;
  * @param {ASTNode} node A Markdown code block AST node.
  * @param {comments} comments List of configuration comment strings that will be
  *     inserted at the beginning of the code block.
- * @returns {object[]} A list of offset-based adjustments, where lookups are
+ * @returns {Object[]} A list of offset-based adjustments, where lookups are
  *     done based on the `js` key, which represents the range in the linted JS,
  *     and the `md` key is the offset delta that, when added to the JS range,
  *     returns the corresponding location in the original Markdown source.
  */
 function getBlockRangeMap(text, node, comments) {
-    var baseIndent,
+    let baseIndent,
         code,
         commentLength,
         i,
@@ -139,16 +139,14 @@ function getBlockRangeMap(text, node, comments) {
      * backtick's column is the AST node's starting column plus any additional
      * indentation.
      */
-    baseIndent = node.position.start.column - 1
-        + leadingWhitespaceRegex.exec(lines[0])[0].length;
+    baseIndent = node.position.start.column - 1 +
+        leadingWhitespaceRegex.exec(lines[0])[0].length;
 
     /*
      * Track the length of any inserted configuration comments at the beginning
      * of the linted JS and start the JS offset lookup keys at this index.
      */
-    commentLength = comments.reduce(function(len, comment) {
-        return len + comment.length + 1;
-    }, 0);
+    commentLength = comments.reduce((len, comment) => len + comment.length + 1, 0);
 
     /*
      * In case there are configuration comments, initialize the map so that the
@@ -179,12 +177,14 @@ function getBlockRangeMap(text, node, comments) {
     for (i = 0; i + 1 < lines.length; i++) {
         line = lines[i + 1];
         leadingWhitespaceLength = leadingWhitespaceRegex.exec(line)[0].length;
+
         // The parser trims leading whitespace up to the level of the opening
         // fence, so keep any additional indentation beyond that.
         trimLength = Math.min(baseIndent, leadingWhitespaceLength);
 
         rangeMap.push({
             js: jsOffset,
+
             // Advance `trimLength` character from the beginning of the Markdown
             // line to the beginning of the equivalent JS line, then compute the
             // delta.
@@ -205,13 +205,13 @@ function getBlockRangeMap(text, node, comments) {
  * @returns {string[]} Source code strings to lint.
  */
 function preprocess(text) {
-    var ast = markdown.parse(text);
+    const ast = markdown.parse(text);
 
     blocks = [];
     traverse(ast, {
-        "code": function(node, parent) {
-            var comments = [];
-            var index, previousNode, comment;
+        code(node, parent) {
+            const comments = [];
+            let index, previousNode, comment;
 
             if (node.lang && SUPPORTED_SYNTAXES.indexOf(node.lang.split(" ")[0].toLowerCase()) >= 0) {
                 index = parent.children.indexOf(node) - 1;
@@ -227,35 +227,31 @@ function preprocess(text) {
                         return;
                     }
 
-                    comments.unshift("/*" + comment + "*/");
+                    comments.unshift(`/*${comment}*/`);
                     index--;
                     previousNode = parent.children[index];
                 }
 
                 blocks.push(assign({}, node, {
-                    comments: comments,
+                    comments,
                     rangeMap: getBlockRangeMap(text, node, comments)
                 }));
             }
         }
     });
 
-    return blocks.map(function(block) {
-        return block.comments.concat(block.value).concat("").join("\n");
-    });
+    return blocks.map(block => block.comments.concat(block.value).concat("").join("\n"));
 }
 
 /**
  * Creates a map function that adjusts messages in a code block.
  * @param {Block} block A code block.
- * @returns {function} A function that adjusts messages in a code block.
+ * @returns {Function} A function that adjusts messages in a code block.
  */
 function adjustBlock(block) {
-    var leadingCommentLines = block.comments.reduce(function(count, comment) {
-        return count + comment.split("\n").length;
-    }, 0);
+    const leadingCommentLines = block.comments.reduce((count, comment) => count + comment.split("\n").length, 0);
 
-    var blockStart = block.position.start.line;
+    const blockStart = block.position.start.line;
 
     /**
      * Adjusts ESLint messages to point to the correct location in the Markdown.
@@ -264,26 +260,30 @@ function adjustBlock(block) {
      */
     return function adjustMessage(message) {
 
-        var lineInCode = message.line - leadingCommentLines;
-        var endLine = message.endLine - leadingCommentLines;
+        const lineInCode = message.line - leadingCommentLines;
+        const endLine = message.endLine - leadingCommentLines;
+
         if (lineInCode < 1) {
             return null;
         }
 
-        var out = {
+        const out = {
             line: lineInCode + blockStart,
             endLine: endLine ? endLine + blockStart : endLine,
             column: message.column + block.position.indent[lineInCode - 1] - 1
         };
 
-        var adjustedFix = {};
+        const adjustedFix = {};
+
         if (message.fix) {
             adjustedFix.fix = {
-                range: message.fix.range.map(function(range) {
+                range: message.fix.range.map(range => {
+
                     // Advance through the block's range map to find the last
                     // matching range by finding the first range too far and
                     // then going back one.
-                    var i = 1;
+                    let i = 1;
+
                     while (i < block.rangeMap.length && block.rangeMap[i].js < range) {
                         i++;
                     }
@@ -315,14 +315,15 @@ function excludeUnsatisfiableRules(message) {
  * @returns {Message[]} A flattened array of messages with mapped locations.
  */
 function postprocess(messages) {
-    return [].concat.apply([], messages.map(function(group, i) {
-        var adjust = adjustBlock(blocks[i]);
+    return [].concat.apply([], messages.map((group, i) => {
+        const adjust = adjustBlock(blocks[i]);
+
         return group.map(adjust).filter(excludeUnsatisfiableRules);
     }));
 }
 
 module.exports = {
-    preprocess: preprocess,
-    postprocess: postprocess,
+    preprocess,
+    postprocess,
     supportsAutofix: SUPPORTS_AUTOFIX
 };

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
   "devDependencies": {
     "chai": "^3.0.0",
     "eslint": "^4.19.1",
-    "eslint-config-eslint": "^3.0.0",
+    "eslint-config-eslint": "^5.0.1",
+    "eslint-plugin-node": "^6.0.1",
     "eslint-release": "^1.0.0",
     "istanbul": "^0.4.5",
     "mocha": "^2.2.5"

--- a/tests/lib/plugin.js
+++ b/tests/lib/plugin.js
@@ -5,10 +5,10 @@
 
 "use strict";
 
-let assert = require("chai").assert,
-    CLIEngine = require("eslint").CLIEngine,
-    path = require("path"),
-    plugin = require("../..");
+const assert = require("chai").assert;
+const CLIEngine = require("eslint").CLIEngine;
+const path = require("path");
+const plugin = require("../..");
 
 /**
  * Helper function which creates CLIEngine instance with enabled/disabled autofix feature.

--- a/tests/lib/plugin.js
+++ b/tests/lib/plugin.js
@@ -52,10 +52,10 @@ describe("plugin", () => {
     it("should run on .md files", () => {
         const report = cli.executeOnText(shortText, "test.md");
 
-        assert.equal(report.results.length, 1);
-        assert.equal(report.results[0].messages.length, 1);
-        assert.equal(report.results[0].messages[0].message, "Unexpected console statement.");
-        assert.equal(report.results[0].messages[0].line, 2);
+        assert.strictEqual(report.results.length, 1);
+        assert.strictEqual(report.results[0].messages.length, 1);
+        assert.strictEqual(report.results[0].messages[0].message, "Unexpected console statement.");
+        assert.strictEqual(report.results[0].messages[0].line, 2);
     });
 
     it("should emit correct line numbers", () => {
@@ -72,12 +72,12 @@ describe("plugin", () => {
         ].join("\n");
         const report = cli.executeOnText(code, "test.md");
 
-        assert.equal(report.results[0].messages[0].message, "'baz' is not defined.");
-        assert.equal(report.results[0].messages[0].line, 5);
-        assert.equal(report.results[0].messages[0].endLine, 5);
-        assert.equal(report.results[0].messages[1].message, "'blah' is not defined.");
-        assert.equal(report.results[0].messages[1].line, 8);
-        assert.equal(report.results[0].messages[1].endLine, 8);
+        assert.strictEqual(report.results[0].messages[0].message, "'baz' is not defined.");
+        assert.strictEqual(report.results[0].messages[0].line, 5);
+        assert.strictEqual(report.results[0].messages[0].endLine, 5);
+        assert.strictEqual(report.results[0].messages[1].message, "'blah' is not defined.");
+        assert.strictEqual(report.results[0].messages[1].line, 8);
+        assert.strictEqual(report.results[0].messages[1].endLine, 8);
     });
 
     it("should emit correct line numbers with leading comments", () => {
@@ -97,61 +97,61 @@ describe("plugin", () => {
         ].join("\n");
         const report = cli.executeOnText(code, "test.md");
 
-        assert.equal(report.results[0].messages[0].message, "'baz' is not defined.");
-        assert.equal(report.results[0].messages[0].line, 7);
-        assert.equal(report.results[0].messages[0].endLine, 7);
-        assert.equal(report.results[0].messages[1].message, "'blah' is not defined.");
-        assert.equal(report.results[0].messages[1].line, 11);
-        assert.equal(report.results[0].messages[1].endLine, 11);
+        assert.strictEqual(report.results[0].messages[0].message, "'baz' is not defined.");
+        assert.strictEqual(report.results[0].messages[0].line, 7);
+        assert.strictEqual(report.results[0].messages[0].endLine, 7);
+        assert.strictEqual(report.results[0].messages[1].message, "'blah' is not defined.");
+        assert.strictEqual(report.results[0].messages[1].line, 11);
+        assert.strictEqual(report.results[0].messages[1].endLine, 11);
     });
 
     it("should run on .mkdn files", () => {
         const report = cli.executeOnText(shortText, "test.mkdn");
 
-        assert.equal(report.results.length, 1);
-        assert.equal(report.results[0].messages.length, 1);
-        assert.equal(report.results[0].messages[0].message, "Unexpected console statement.");
-        assert.equal(report.results[0].messages[0].line, 2);
+        assert.strictEqual(report.results.length, 1);
+        assert.strictEqual(report.results[0].messages.length, 1);
+        assert.strictEqual(report.results[0].messages[0].message, "Unexpected console statement.");
+        assert.strictEqual(report.results[0].messages[0].line, 2);
     });
 
     it("should run on .mdown files", () => {
         const report = cli.executeOnText(shortText, "test.mdown");
 
-        assert.equal(report.results.length, 1);
-        assert.equal(report.results[0].messages.length, 1);
-        assert.equal(report.results[0].messages[0].message, "Unexpected console statement.");
-        assert.equal(report.results[0].messages[0].line, 2);
+        assert.strictEqual(report.results.length, 1);
+        assert.strictEqual(report.results[0].messages.length, 1);
+        assert.strictEqual(report.results[0].messages[0].message, "Unexpected console statement.");
+        assert.strictEqual(report.results[0].messages[0].line, 2);
     });
 
     it("should run on .markdown files", () => {
         const report = cli.executeOnText(shortText, "test.markdown");
 
-        assert.equal(report.results.length, 1);
-        assert.equal(report.results[0].messages.length, 1);
-        assert.equal(report.results[0].messages[0].message, "Unexpected console statement.");
-        assert.equal(report.results[0].messages[0].line, 2);
+        assert.strictEqual(report.results.length, 1);
+        assert.strictEqual(report.results[0].messages.length, 1);
+        assert.strictEqual(report.results[0].messages[0].message, "Unexpected console statement.");
+        assert.strictEqual(report.results[0].messages[0].line, 2);
     });
 
     it("should extract blocks and remap messages", () => {
         const report = cli.executeOnFiles([path.resolve(__dirname, "../fixtures/long.md")]);
 
-        assert.equal(report.results.length, 1);
-        assert.equal(report.results[0].messages.length, 5);
-        assert.equal(report.results[0].messages[0].message, "Unexpected console statement.");
-        assert.equal(report.results[0].messages[0].line, 10);
-        assert.equal(report.results[0].messages[0].column, 1);
-        assert.equal(report.results[0].messages[1].message, "Unexpected console statement.");
-        assert.equal(report.results[0].messages[1].line, 16);
-        assert.equal(report.results[0].messages[1].column, 5);
-        assert.equal(report.results[0].messages[2].message, "Unexpected console statement.");
-        assert.equal(report.results[0].messages[2].line, 24);
-        assert.equal(report.results[0].messages[2].column, 1);
-        assert.equal(report.results[0].messages[3].message, "Strings must use singlequote.");
-        assert.equal(report.results[0].messages[3].line, 38);
-        assert.equal(report.results[0].messages[3].column, 13);
-        assert.equal(report.results[0].messages[4].message, "Parsing error: Unexpected character '@'");
-        assert.equal(report.results[0].messages[4].line, 46);
-        assert.equal(report.results[0].messages[4].column, 2);
+        assert.strictEqual(report.results.length, 1);
+        assert.strictEqual(report.results[0].messages.length, 5);
+        assert.strictEqual(report.results[0].messages[0].message, "Unexpected console statement.");
+        assert.strictEqual(report.results[0].messages[0].line, 10);
+        assert.strictEqual(report.results[0].messages[0].column, 1);
+        assert.strictEqual(report.results[0].messages[1].message, "Unexpected console statement.");
+        assert.strictEqual(report.results[0].messages[1].line, 16);
+        assert.strictEqual(report.results[0].messages[1].column, 5);
+        assert.strictEqual(report.results[0].messages[2].message, "Unexpected console statement.");
+        assert.strictEqual(report.results[0].messages[2].line, 24);
+        assert.strictEqual(report.results[0].messages[2].column, 1);
+        assert.strictEqual(report.results[0].messages[3].message, "Strings must use singlequote.");
+        assert.strictEqual(report.results[0].messages[3].line, 38);
+        assert.strictEqual(report.results[0].messages[3].column, 13);
+        assert.strictEqual(report.results[0].messages[4].message, "Parsing error: Unexpected character '@'");
+        assert.strictEqual(report.results[0].messages[4].line, 46);
+        assert.strictEqual(report.results[0].messages[4].column, 2);
     });
 
     describe("configuration comments", () => {
@@ -177,16 +177,16 @@ describe("plugin", () => {
             ].join("\n");
             const report = cli.executeOnText(code, "test.md");
 
-            assert.equal(report.results.length, 1);
-            assert.equal(report.results[0].messages.length, 4);
-            assert.equal(report.results[0].messages[0].message, "Strings must use singlequote.");
-            assert.equal(report.results[0].messages[0].line, 7);
-            assert.equal(report.results[0].messages[1].message, "Strings must use doublequote.");
-            assert.equal(report.results[0].messages[1].line, 12);
-            assert.equal(report.results[0].messages[2].message, "Unexpected console statement.");
-            assert.equal(report.results[0].messages[2].line, 13);
-            assert.equal(report.results[0].messages[3].message, "Unexpected console statement.");
-            assert.equal(report.results[0].messages[3].line, 15);
+            assert.strictEqual(report.results.length, 1);
+            assert.strictEqual(report.results[0].messages.length, 4);
+            assert.strictEqual(report.results[0].messages[0].message, "Strings must use singlequote.");
+            assert.strictEqual(report.results[0].messages[0].line, 7);
+            assert.strictEqual(report.results[0].messages[1].message, "Strings must use doublequote.");
+            assert.strictEqual(report.results[0].messages[1].line, 12);
+            assert.strictEqual(report.results[0].messages[2].message, "Unexpected console statement.");
+            assert.strictEqual(report.results[0].messages[2].line, 13);
+            assert.strictEqual(report.results[0].messages[3].message, "Unexpected console statement.");
+            assert.strictEqual(report.results[0].messages[3].line, 15);
         });
 
     });
@@ -215,7 +215,7 @@ describe("plugin", () => {
             const report = cli.executeOnText(input, "test.md");
             const actual = report.results[0].output;
 
-            assert.equal(actual, expected);
+            assert.strictEqual(actual, expected);
         });
 
         it("across multiple lines", () => {
@@ -238,7 +238,7 @@ describe("plugin", () => {
             const report = cli.executeOnText(input, "test.md");
             const actual = report.results[0].output;
 
-            assert.equal(actual, expected);
+            assert.strictEqual(actual, expected);
         });
 
         it("across multiple blocks", () => {
@@ -267,7 +267,7 @@ describe("plugin", () => {
             const report = cli.executeOnText(input, "test.md");
             const actual = report.results[0].output;
 
-            assert.equal(actual, expected);
+            assert.strictEqual(actual, expected);
         });
 
         it("with lines indented by spaces", () => {
@@ -292,7 +292,7 @@ describe("plugin", () => {
             const report = cli.executeOnText(input, "test.md");
             const actual = report.results[0].output;
 
-            assert.equal(actual, expected);
+            assert.strictEqual(actual, expected);
         });
 
         it("with lines indented by tabs", () => {
@@ -317,7 +317,7 @@ describe("plugin", () => {
             const report = cli.executeOnText(input, "test.md");
             const actual = report.results[0].output;
 
-            assert.equal(actual, expected);
+            assert.strictEqual(actual, expected);
         });
 
         it("in blocks with uncommon tags", () => {
@@ -338,7 +338,7 @@ describe("plugin", () => {
             const report = cli.executeOnText(input, "test.md");
             const actual = report.results[0].output;
 
-            assert.equal(actual, expected);
+            assert.strictEqual(actual, expected);
         });
 
         it("in blocks with extra backticks", () => {
@@ -359,7 +359,7 @@ describe("plugin", () => {
             const report = cli.executeOnText(input, "test.md");
             const actual = report.results[0].output;
 
-            assert.equal(actual, expected);
+            assert.strictEqual(actual, expected);
         });
 
         it("with configuration comments", () => {
@@ -380,7 +380,7 @@ describe("plugin", () => {
             const report = cli.executeOnText(input, "test.md");
             const actual = report.results[0].output;
 
-            assert.equal(actual, expected);
+            assert.strictEqual(actual, expected);
         });
 
         it("inside a list single line", () => {
@@ -401,7 +401,7 @@ describe("plugin", () => {
             const report = cli.executeOnText(input, "test.md");
             const actual = report.results[0].output;
 
-            assert.equal(actual, expected);
+            assert.strictEqual(actual, expected);
         });
 
         it("inside a list multi line", () => {
@@ -432,7 +432,7 @@ describe("plugin", () => {
             const report = cli.executeOnText(input, "test.md");
             const actual = report.results[0].output;
 
-            assert.equal(actual, expected);
+            assert.strictEqual(actual, expected);
         });
 
         // https://spec.commonmark.org/0.28/#fenced-code-blocks
@@ -457,7 +457,7 @@ describe("plugin", () => {
                 const report = cli.executeOnText(input, "test.md");
                 const actual = report.results[0].output;
 
-                assert.equal(actual, expected);
+                assert.strictEqual(actual, expected);
             });
 
             it("by two spaces", () => {
@@ -480,7 +480,7 @@ describe("plugin", () => {
                 const report = cli.executeOnText(input, "test.md");
                 const actual = report.results[0].output;
 
-                assert.equal(actual, expected);
+                assert.strictEqual(actual, expected);
             });
 
             it("by three spaces", () => {
@@ -503,7 +503,7 @@ describe("plugin", () => {
                 const report = cli.executeOnText(input, "test.md");
                 const actual = report.results[0].output;
 
-                assert.equal(actual, expected);
+                assert.strictEqual(actual, expected);
             });
 
             it("and the closing fence is differently indented", () => {
@@ -526,7 +526,7 @@ describe("plugin", () => {
                 const report = cli.executeOnText(input, "test.md");
                 const actual = report.results[0].output;
 
-                assert.equal(actual, expected);
+                assert.strictEqual(actual, expected);
             });
 
             it("underindented", () => {
@@ -551,7 +551,7 @@ describe("plugin", () => {
                 const report = cli.executeOnText(input, "test.md");
                 const actual = report.results[0].output;
 
-                assert.equal(actual, expected);
+                assert.strictEqual(actual, expected);
             });
 
             it("by one space with comments", () => {
@@ -580,7 +580,7 @@ describe("plugin", () => {
                 const report = cli.executeOnText(input, "test.md");
                 const actual = report.results[0].output;
 
-                assert.equal(actual, expected);
+                assert.strictEqual(actual, expected);
             });
 
             it("unevenly by two spaces with comments", () => {
@@ -611,7 +611,7 @@ describe("plugin", () => {
                 const report = cli.executeOnText(input, "test.md");
                 const actual = report.results[0].output;
 
-                assert.equal(actual, expected);
+                assert.strictEqual(actual, expected);
             });
 
             describe("inside a list", () => {
@@ -635,7 +635,7 @@ describe("plugin", () => {
                     const report = cli.executeOnText(input, "test.md");
                     const actual = report.results[0].output;
 
-                    assert.equal(actual, expected);
+                    assert.strictEqual(actual, expected);
                 });
 
                 it("by one space", () => {
@@ -658,7 +658,7 @@ describe("plugin", () => {
                     const report = cli.executeOnText(input, "test.md");
                     const actual = report.results[0].output;
 
-                    assert.equal(actual, expected);
+                    assert.strictEqual(actual, expected);
                 });
             });
         });
@@ -701,7 +701,7 @@ describe("plugin", () => {
             const report = cli.executeOnText(input, "test.md");
             const actual = report.results[0].output;
 
-            assert.equal(actual, expected);
+            assert.strictEqual(actual, expected);
         });
 
     });

--- a/tests/lib/plugin.js
+++ b/tests/lib/plugin.js
@@ -5,7 +5,7 @@
 
 "use strict";
 
-var assert = require("chai").assert,
+let assert = require("chai").assert,
     CLIEngine = require("eslint").CLIEngine,
     path = require("path"),
     plugin = require("../..");
@@ -16,40 +16,41 @@ var assert = require("chai").assert,
  * @returns {CLIEngine} CLIEngine instance to execute in tests.
  */
 function initCLI(isAutofixEnabled) {
-    var fix = isAutofixEnabled || false;
-    var cli = new CLIEngine({
+    const fix = isAutofixEnabled || false;
+    const cli = new CLIEngine({
         envs: ["browser"],
         extensions: ["md", "mkdn", "mdown", "markdown"],
-        fix: fix,
+        fix,
         ignore: false,
         rules: {
             "eol-last": 2,
             "no-console": 2,
             "no-undef": 2,
-            "quotes": 2,
+            quotes: 2,
             "spaced-comment": 2
         },
         useEslintrc: false
     });
+
     cli.addPlugin("markdown", plugin);
     return cli;
 }
 
-describe("plugin", function() {
+describe("plugin", () => {
 
-    var cli;
-    var shortText = [
+    let cli;
+    const shortText = [
         "```js",
         "console.log(42);",
         "```"
     ].join("\n");
 
-    before(function() {
+    before(() => {
         cli = initCLI();
     });
 
-    it("should run on .md files", function() {
-        var report = cli.executeOnText(shortText, "test.md");
+    it("should run on .md files", () => {
+        const report = cli.executeOnText(shortText, "test.md");
 
         assert.equal(report.results.length, 1);
         assert.equal(report.results[0].messages.length, 1);
@@ -57,8 +58,8 @@ describe("plugin", function() {
         assert.equal(report.results[0].messages[0].line, 2);
     });
 
-    it("should emit correct line numbers", function() {
-        var code = [
+    it("should emit correct line numbers", () => {
+        const code = [
             "# Hello, world!",
             "",
             "",
@@ -69,7 +70,8 @@ describe("plugin", function() {
             "var foo = blah",
             "```"
         ].join("\n");
-        var report = cli.executeOnText(code, "test.md");
+        const report = cli.executeOnText(code, "test.md");
+
         assert.equal(report.results[0].messages[0].message, "'baz' is not defined.");
         assert.equal(report.results[0].messages[0].line, 5);
         assert.equal(report.results[0].messages[0].endLine, 5);
@@ -78,8 +80,8 @@ describe("plugin", function() {
         assert.equal(report.results[0].messages[1].endLine, 8);
     });
 
-    it("should emit correct line numbers with leading comments", function() {
-        var code = [
+    it("should emit correct line numbers with leading comments", () => {
+        const code = [
             "# Hello, world!",
             "",
             "<!-- eslint-disable quotes -->",
@@ -93,7 +95,8 @@ describe("plugin", function() {
             "var foo = blah",
             "```"
         ].join("\n");
-        var report = cli.executeOnText(code, "test.md");
+        const report = cli.executeOnText(code, "test.md");
+
         assert.equal(report.results[0].messages[0].message, "'baz' is not defined.");
         assert.equal(report.results[0].messages[0].line, 7);
         assert.equal(report.results[0].messages[0].endLine, 7);
@@ -102,8 +105,8 @@ describe("plugin", function() {
         assert.equal(report.results[0].messages[1].endLine, 11);
     });
 
-    it("should run on .mkdn files", function() {
-        var report = cli.executeOnText(shortText, "test.mkdn");
+    it("should run on .mkdn files", () => {
+        const report = cli.executeOnText(shortText, "test.mkdn");
 
         assert.equal(report.results.length, 1);
         assert.equal(report.results[0].messages.length, 1);
@@ -111,8 +114,8 @@ describe("plugin", function() {
         assert.equal(report.results[0].messages[0].line, 2);
     });
 
-    it("should run on .mdown files", function() {
-        var report = cli.executeOnText(shortText, "test.mdown");
+    it("should run on .mdown files", () => {
+        const report = cli.executeOnText(shortText, "test.mdown");
 
         assert.equal(report.results.length, 1);
         assert.equal(report.results[0].messages.length, 1);
@@ -120,8 +123,8 @@ describe("plugin", function() {
         assert.equal(report.results[0].messages[0].line, 2);
     });
 
-    it("should run on .markdown files", function() {
-        var report = cli.executeOnText(shortText, "test.markdown");
+    it("should run on .markdown files", () => {
+        const report = cli.executeOnText(shortText, "test.markdown");
 
         assert.equal(report.results.length, 1);
         assert.equal(report.results[0].messages.length, 1);
@@ -129,8 +132,8 @@ describe("plugin", function() {
         assert.equal(report.results[0].messages[0].line, 2);
     });
 
-    it("should extract blocks and remap messages", function() {
-        var report = cli.executeOnFiles([path.resolve(__dirname, "../fixtures/long.md")]);
+    it("should extract blocks and remap messages", () => {
+        const report = cli.executeOnFiles([path.resolve(__dirname, "../fixtures/long.md")]);
 
         assert.equal(report.results.length, 1);
         assert.equal(report.results[0].messages.length, 5);
@@ -151,10 +154,10 @@ describe("plugin", function() {
         assert.equal(report.results[0].messages[4].column, 2);
     });
 
-    describe("configuration comments", function() {
+    describe("configuration comments", () => {
 
-        it("apply only to the code block immediately following", function() {
-            var code = [
+        it("apply only to the code block immediately following", () => {
+            const code = [
                 "<!-- eslint \"quotes\": [\"error\", \"single\"] -->",
                 "<!-- eslint-disable no-console -->",
                 "",
@@ -172,7 +175,7 @@ describe("plugin", function() {
                 "console.log(double);",
                 "```"
             ].join("\n");
-            var report = cli.executeOnText(code, "test.md");
+            const report = cli.executeOnText(code, "test.md");
 
             assert.equal(report.results.length, 1);
             assert.equal(report.results[0].messages.length, 4);
@@ -188,58 +191,58 @@ describe("plugin", function() {
 
     });
 
-    describe("should fix code", function() {
+    describe("should fix code", () => {
 
-        before(function() {
+        before(() => {
             cli = initCLI(true);
         });
 
-        it("in the simplest case", function() {
-            var input = [
+        it("in the simplest case", () => {
+            const input = [
                 "This is Markdown.",
                 "",
                 "```js",
                 "console.log('Hello, world!')",
-                "```",
+                "```"
             ].join("\n");
-            var expected = [
+            const expected = [
                 "This is Markdown.",
                 "",
                 "```js",
                 "console.log(\"Hello, world!\")",
-                "```",
+                "```"
             ].join("\n");
-            var report = cli.executeOnText(input, "test.md");
-            var actual = report.results[0].output;
+            const report = cli.executeOnText(input, "test.md");
+            const actual = report.results[0].output;
 
             assert.equal(actual, expected);
         });
 
-        it("across multiple lines", function() {
-            var input = [
+        it("across multiple lines", () => {
+            const input = [
                 "This is Markdown.",
                 "",
                 "```js",
                 "console.log('Hello, world!')",
                 "console.log('Hello, world!')",
-                "```",
+                "```"
             ].join("\n");
-            var expected = [
+            const expected = [
                 "This is Markdown.",
                 "",
                 "```js",
                 "console.log(\"Hello, world!\")",
                 "console.log(\"Hello, world!\")",
-                "```",
+                "```"
             ].join("\n");
-            var report = cli.executeOnText(input, "test.md");
-            var actual = report.results[0].output;
+            const report = cli.executeOnText(input, "test.md");
+            const actual = report.results[0].output;
 
             assert.equal(actual, expected);
         });
 
-        it("across multiple blocks", function() {
-            var input = [
+        it("across multiple blocks", () => {
+            const input = [
                 "This is Markdown.",
                 "",
                 "```js",
@@ -248,9 +251,9 @@ describe("plugin", function() {
                 "",
                 "```js",
                 "console.log('Hello, world!')",
-                "```",
+                "```"
             ].join("\n");
-            var expected = [
+            const expected = [
                 "This is Markdown.",
                 "",
                 "```js",
@@ -259,150 +262,150 @@ describe("plugin", function() {
                 "",
                 "```js",
                 "console.log(\"Hello, world!\")",
-                "```",
+                "```"
             ].join("\n");
-            var report = cli.executeOnText(input, "test.md");
-            var actual = report.results[0].output;
+            const report = cli.executeOnText(input, "test.md");
+            const actual = report.results[0].output;
 
             assert.equal(actual, expected);
         });
 
-        it("with lines indented by spaces", function() {
-            var input = [
+        it("with lines indented by spaces", () => {
+            const input = [
                 "This is Markdown.",
                 "",
                 "```js",
                 "function test() {",
                 "    console.log('Hello, world!')",
                 "}",
-                "```",
+                "```"
             ].join("\n");
-            var expected = [
+            const expected = [
                 "This is Markdown.",
                 "",
                 "```js",
                 "function test() {",
                 "    console.log(\"Hello, world!\")",
                 "}",
-                "```",
+                "```"
             ].join("\n");
-            var report = cli.executeOnText(input, "test.md");
-            var actual = report.results[0].output;
+            const report = cli.executeOnText(input, "test.md");
+            const actual = report.results[0].output;
 
             assert.equal(actual, expected);
         });
 
-        it("with lines indented by tabs", function() {
-            var input = [
+        it("with lines indented by tabs", () => {
+            const input = [
                 "This is Markdown.",
                 "",
                 "```js",
                 "function test() {",
                 "\tconsole.log('Hello, world!')",
                 "}",
-                "```",
+                "```"
             ].join("\n");
-            var expected = [
+            const expected = [
                 "This is Markdown.",
                 "",
                 "```js",
                 "function test() {",
                 "\tconsole.log(\"Hello, world!\")",
                 "}",
-                "```",
+                "```"
             ].join("\n");
-            var report = cli.executeOnText(input, "test.md");
-            var actual = report.results[0].output;
+            const report = cli.executeOnText(input, "test.md");
+            const actual = report.results[0].output;
 
             assert.equal(actual, expected);
         });
 
-        it("in blocks with uncommon tags", function() {
-            var input = [
+        it("in blocks with uncommon tags", () => {
+            const input = [
                 "This is Markdown.",
                 "",
                 "```JavaScript",
                 "console.log('Hello, world!')",
-                "```",
+                "```"
             ].join("\n");
-            var expected = [
+            const expected = [
                 "This is Markdown.",
                 "",
                 "```JavaScript",
                 "console.log(\"Hello, world!\")",
-                "```",
+                "```"
             ].join("\n");
-            var report = cli.executeOnText(input, "test.md");
-            var actual = report.results[0].output;
+            const report = cli.executeOnText(input, "test.md");
+            const actual = report.results[0].output;
 
             assert.equal(actual, expected);
         });
 
-        it("in blocks with extra backticks", function() {
-            var input = [
+        it("in blocks with extra backticks", () => {
+            const input = [
                 "This is Markdown.",
                 "",
                 "````js",
                 "console.log('Hello, world!')",
-                "````",
+                "````"
             ].join("\n");
-            var expected = [
+            const expected = [
                 "This is Markdown.",
                 "",
                 "````js",
                 "console.log(\"Hello, world!\")",
-                "````",
+                "````"
             ].join("\n");
-            var report = cli.executeOnText(input, "test.md");
-            var actual = report.results[0].output;
+            const report = cli.executeOnText(input, "test.md");
+            const actual = report.results[0].output;
 
             assert.equal(actual, expected);
         });
 
-        it("with configuration comments", function() {
-            var input = [
+        it("with configuration comments", () => {
+            const input = [
                 "<!-- eslint semi: 2 -->",
                 "",
                 "```js",
                 "console.log('Hello, world!')",
-                "```",
+                "```"
             ].join("\n");
-            var expected = [
+            const expected = [
                 "<!-- eslint semi: 2 -->",
                 "",
                 "```js",
                 "console.log(\"Hello, world!\");",
-                "```",
+                "```"
             ].join("\n");
-            var report = cli.executeOnText(input, "test.md");
-            var actual = report.results[0].output;
+            const report = cli.executeOnText(input, "test.md");
+            const actual = report.results[0].output;
 
             assert.equal(actual, expected);
         });
 
-        it("inside a list single line", function() {
-            var input = [
+        it("inside a list single line", () => {
+            const input = [
                 "- Inside a list",
                 "",
                 "  ```js",
                 "  console.log('Hello, world!')",
-                "  ```",
+                "  ```"
             ].join("\n");
-            var expected = [
+            const expected = [
                 "- Inside a list",
                 "",
                 "  ```js",
                 "  console.log(\"Hello, world!\")",
-                "  ```",
+                "  ```"
             ].join("\n");
-            var report = cli.executeOnText(input, "test.md");
-            var actual = report.results[0].output;
+            const report = cli.executeOnText(input, "test.md");
+            const actual = report.results[0].output;
 
             assert.equal(actual, expected);
         });
 
-        it("inside a list multi line", function() {
-            var input = [
+        it("inside a list multi line", () => {
+            const input = [
                 "- Inside a list",
                 "",
                 "   ```js",
@@ -412,9 +415,9 @@ describe("plugin", function() {
                 "   var obj = {",
                 "     hello: 'value'",
                 "   }",
-                "   ```",
+                "   ```"
             ].join("\n");
-            var expected = [
+            const expected = [
                 "- Inside a list",
                 "",
                 "   ```js",
@@ -424,18 +427,18 @@ describe("plugin", function() {
                 "   var obj = {",
                 "     hello: \"value\"",
                 "   }",
-                "   ```",
+                "   ```"
             ].join("\n");
-            var report = cli.executeOnText(input, "test.md");
-            var actual = report.results[0].output;
+            const report = cli.executeOnText(input, "test.md");
+            const actual = report.results[0].output;
 
             assert.equal(actual, expected);
         });
 
         // https://spec.commonmark.org/0.28/#fenced-code-blocks
-        describe("when indented", function() {
-            it("by one space", function() {
-                var input = [
+        describe("when indented", () => {
+            it("by one space", () => {
+                const input = [
                     "This is Markdown.",
                     "",
                     " ```js",
@@ -443,7 +446,7 @@ describe("plugin", function() {
                     " console.log('Hello, world!')",
                     " ```"
                 ].join("\n");
-                var expected = [
+                const expected = [
                     "This is Markdown.",
                     "",
                     " ```js",
@@ -451,14 +454,14 @@ describe("plugin", function() {
                     " console.log(\"Hello, world!\")",
                     " ```"
                 ].join("\n");
-                var report = cli.executeOnText(input, "test.md");
-                var actual = report.results[0].output;
+                const report = cli.executeOnText(input, "test.md");
+                const actual = report.results[0].output;
 
                 assert.equal(actual, expected);
             });
 
-            it("by two spaces", function() {
-                var input = [
+            it("by two spaces", () => {
+                const input = [
                     "This is Markdown.",
                     "",
                     "  ```js",
@@ -466,7 +469,7 @@ describe("plugin", function() {
                     "  console.log('Hello, world!')",
                     "  ```"
                 ].join("\n");
-                var expected = [
+                const expected = [
                     "This is Markdown.",
                     "",
                     "  ```js",
@@ -474,14 +477,14 @@ describe("plugin", function() {
                     "  console.log(\"Hello, world!\")",
                     "  ```"
                 ].join("\n");
-                var report = cli.executeOnText(input, "test.md");
-                var actual = report.results[0].output;
+                const report = cli.executeOnText(input, "test.md");
+                const actual = report.results[0].output;
 
                 assert.equal(actual, expected);
             });
 
-            it("by three spaces", function() {
-                var input = [
+            it("by three spaces", () => {
+                const input = [
                     "This is Markdown.",
                     "",
                     "   ```js",
@@ -489,7 +492,7 @@ describe("plugin", function() {
                     "   console.log('Hello, world!')",
                     "   ```"
                 ].join("\n");
-                var expected = [
+                const expected = [
                     "This is Markdown.",
                     "",
                     "   ```js",
@@ -497,14 +500,14 @@ describe("plugin", function() {
                     "   console.log(\"Hello, world!\")",
                     "   ```"
                 ].join("\n");
-                var report = cli.executeOnText(input, "test.md");
-                var actual = report.results[0].output;
+                const report = cli.executeOnText(input, "test.md");
+                const actual = report.results[0].output;
 
                 assert.equal(actual, expected);
             });
 
-            it("and the closing fence is differently indented", function() {
-                var input = [
+            it("and the closing fence is differently indented", () => {
+                const input = [
                     "This is Markdown.",
                     "",
                     " ```js",
@@ -512,7 +515,7 @@ describe("plugin", function() {
                     " console.log('Hello, world!')",
                     "   ```"
                 ].join("\n");
-                var expected = [
+                const expected = [
                     "This is Markdown.",
                     "",
                     " ```js",
@@ -520,14 +523,14 @@ describe("plugin", function() {
                     " console.log(\"Hello, world!\")",
                     "   ```"
                 ].join("\n");
-                var report = cli.executeOnText(input, "test.md");
-                var actual = report.results[0].output;
+                const report = cli.executeOnText(input, "test.md");
+                const actual = report.results[0].output;
 
                 assert.equal(actual, expected);
             });
 
-            it("underindented", function() {
-                var input = [
+            it("underindented", () => {
+                const input = [
                     "This is Markdown.",
                     "",
                     "   ```js",
@@ -536,7 +539,7 @@ describe("plugin", function() {
                     "     console.log('Hello, world!')",
                     "   ```"
                 ].join("\n");
-                var expected = [
+                const expected = [
                     "This is Markdown.",
                     "",
                     "   ```js",
@@ -545,14 +548,14 @@ describe("plugin", function() {
                     "     console.log(\"Hello, world!\")",
                     "   ```"
                 ].join("\n");
-                var report = cli.executeOnText(input, "test.md");
-                var actual = report.results[0].output;
+                const report = cli.executeOnText(input, "test.md");
+                const actual = report.results[0].output;
 
                 assert.equal(actual, expected);
             });
 
-            it("by one space with comments", function() {
-                var input = [
+            it("by one space with comments", () => {
+                const input = [
                     "This is Markdown.",
                     "",
                     "<!-- eslint semi: 2 -->",
@@ -563,7 +566,7 @@ describe("plugin", function() {
                     " console.log('Hello, world!')",
                     " ```"
                 ].join("\n");
-                var expected = [
+                const expected = [
                     "This is Markdown.",
                     "",
                     "<!-- eslint semi: 2 -->",
@@ -574,14 +577,14 @@ describe("plugin", function() {
                     " console.log(\"Hello, world!\");",
                     " ```"
                 ].join("\n");
-                var report = cli.executeOnText(input, "test.md");
-                var actual = report.results[0].output;
+                const report = cli.executeOnText(input, "test.md");
+                const actual = report.results[0].output;
 
                 assert.equal(actual, expected);
             });
 
-            it("unevenly by two spaces with comments", function() {
-                var input = [
+            it("unevenly by two spaces with comments", () => {
+                const input = [
                     "This is Markdown.",
                     "",
                     "<!-- eslint semi: 2 -->",
@@ -593,7 +596,7 @@ describe("plugin", function() {
                     "   console.log('Hello, world!')",
                     "  ```"
                 ].join("\n");
-                var expected = [
+                const expected = [
                     "This is Markdown.",
                     "",
                     "<!-- eslint semi: 2 -->",
@@ -605,15 +608,15 @@ describe("plugin", function() {
                     "   console.log(\"Hello, world!\");",
                     "  ```"
                 ].join("\n");
-                var report = cli.executeOnText(input, "test.md");
-                var actual = report.results[0].output;
+                const report = cli.executeOnText(input, "test.md");
+                const actual = report.results[0].output;
 
                 assert.equal(actual, expected);
             });
 
-            describe("inside a list", function() {
-                it("normally", function() {
-                    var input = [
+            describe("inside a list", () => {
+                it("normally", () => {
+                    const input = [
                         "- This is a Markdown list.",
                         "",
                         "  ```js",
@@ -621,7 +624,7 @@ describe("plugin", function() {
                         "  console.log('Hello, world!')",
                         "  ```"
                     ].join("\n");
-                    var expected = [
+                    const expected = [
                         "- This is a Markdown list.",
                         "",
                         "  ```js",
@@ -629,14 +632,14 @@ describe("plugin", function() {
                         "  console.log(\"Hello, world!\")",
                         "  ```"
                     ].join("\n");
-                    var report = cli.executeOnText(input, "test.md");
-                    var actual = report.results[0].output;
+                    const report = cli.executeOnText(input, "test.md");
+                    const actual = report.results[0].output;
 
                     assert.equal(actual, expected);
                 });
 
-                it("by one space", function() {
-                    var input = [
+                it("by one space", () => {
+                    const input = [
                         "- This is a Markdown list.",
                         "",
                         "   ```js",
@@ -644,7 +647,7 @@ describe("plugin", function() {
                         "   console.log('Hello, world!')",
                         "   ```"
                     ].join("\n");
-                    var expected = [
+                    const expected = [
                         "- This is a Markdown list.",
                         "",
                         "   ```js",
@@ -652,16 +655,16 @@ describe("plugin", function() {
                         "   console.log(\"Hello, world!\")",
                         "   ```"
                     ].join("\n");
-                    var report = cli.executeOnText(input, "test.md");
-                    var actual = report.results[0].output;
+                    const report = cli.executeOnText(input, "test.md");
+                    const actual = report.results[0].output;
 
                     assert.equal(actual, expected);
                 });
             });
         });
 
-        it("with multiple rules", function() {
-            var input = [
+        it("with multiple rules", () => {
+            const input = [
                 "## Hello!",
                 "",
                 "<!-- eslint semi: 2 -->",
@@ -676,9 +679,9 @@ describe("plugin", function() {
                 "function hello() {",
                 "  return false",
                 "};",
-                "```",
+                "```"
             ].join("\n");
-            var expected = [
+            const expected = [
                 "## Hello!",
                 "",
                 "<!-- eslint semi: 2 -->",
@@ -693,10 +696,10 @@ describe("plugin", function() {
                 "function hello() {",
                 "  return false;",
                 "};",
-                "```",
+                "```"
             ].join("\n");
-            var report = cli.executeOnText(input, "test.md");
-            var actual = report.results[0].output;
+            const report = cli.executeOnText(input, "test.md");
+            const actual = report.results[0].output;
 
             assert.equal(actual, expected);
         });

--- a/tests/lib/processor.js
+++ b/tests/lib/processor.js
@@ -27,13 +27,13 @@ describe("processor", function() {
         it("should ignore normal text", function() {
             var blocks = processor.preprocess("Hello, world!");
 
-            assert.equal(blocks.length, 0);
+            assert.strictEqual(blocks.length, 0);
         });
 
         it("should ignore inline code", function() {
             var blocks = processor.preprocess("Hello, `{{name}}!");
 
-            assert.equal(blocks.length, 0);
+            assert.strictEqual(blocks.length, 0);
         });
 
         it("should ignore space-indented code blocks", function() {
@@ -46,7 +46,7 @@ describe("processor", function() {
             ].join("\n");
             var blocks = processor.preprocess(code);
 
-            assert.equal(blocks.length, 0);
+            assert.strictEqual(blocks.length, 0);
         });
 
         it("should ignore 4-space-indented code fences", function() {
@@ -59,7 +59,7 @@ describe("processor", function() {
             ].join("\n");
             var blocks = processor.preprocess(code);
 
-            assert.equal(blocks.length, 0);
+            assert.strictEqual(blocks.length, 0);
         });
 
         it("should ignore 4-space-indented fence ends", function() {
@@ -72,8 +72,8 @@ describe("processor", function() {
             ].join("\n");
             var blocks = processor.preprocess(code);
 
-            assert.equal(blocks.length, 1);
-            assert.equal(blocks[0], "var answer = 6 * 7;\n    ```\nGoodbye\n");
+            assert.strictEqual(blocks.length, 1);
+            assert.strictEqual(blocks[0], "var answer = 6 * 7;\n    ```\nGoodbye\n");
         });
 
         it("should ignore tab-indented code blocks", function() {
@@ -86,7 +86,7 @@ describe("processor", function() {
             ].join("\n");
             var blocks = processor.preprocess(code);
 
-            assert.equal(blocks.length, 0);
+            assert.strictEqual(blocks.length, 0);
         });
 
         it("should terminate blocks at EOF", function() {
@@ -97,8 +97,8 @@ describe("processor", function() {
             ].join("\n");
             var blocks = processor.preprocess(code);
 
-            assert.equal(blocks.length, 1);
-            assert.equal(blocks[0], "var answer = 6 * 7;\n");
+            assert.strictEqual(blocks.length, 1);
+            assert.strictEqual(blocks[0], "var answer = 6 * 7;\n");
         });
 
         it("should allow backticks or tildes", function() {
@@ -112,9 +112,9 @@ describe("processor", function() {
             ].join("\n");
             var blocks = processor.preprocess(code);
 
-            assert.equal(blocks.length, 2);
-            assert.equal(blocks[0], "backticks\n");
-            assert.equal(blocks[1], "tildes\n");
+            assert.strictEqual(blocks.length, 2);
+            assert.strictEqual(blocks[0], "backticks\n");
+            assert.strictEqual(blocks[1], "tildes\n");
         });
 
         it("should allow more than three fence characters", function() {
@@ -125,8 +125,8 @@ describe("processor", function() {
             ].join("\n");
             var blocks = processor.preprocess(code);
 
-            assert.equal(blocks.length, 1);
-            assert.equal(blocks[0], "four\n");
+            assert.strictEqual(blocks.length, 1);
+            assert.strictEqual(blocks[0], "four\n");
         });
 
         it("should require end fences at least as long as the starting fence", function() {
@@ -144,10 +144,10 @@ describe("processor", function() {
             ].join("\n");
             var blocks = processor.preprocess(code);
 
-            assert.equal(blocks.length, 3);
-            assert.equal(blocks[0], "four\n```\n");
-            assert.equal(blocks[1], "five\n");
-            assert.equal(blocks[2], "six\n");
+            assert.strictEqual(blocks.length, 3);
+            assert.strictEqual(blocks[0], "four\n```\n");
+            assert.strictEqual(blocks[1], "five\n");
+            assert.strictEqual(blocks[2], "six\n");
         });
 
         it("should not allow other content on ending fence line", function() {
@@ -159,8 +159,8 @@ describe("processor", function() {
             ].join("\n");
             var blocks = processor.preprocess(code);
 
-            assert.equal(blocks.length, 1);
-            assert.equal(blocks[0], "test();\n``` end\n");
+            assert.strictEqual(blocks.length, 1);
+            assert.strictEqual(blocks[0], "test();\n``` end\n");
         });
 
         it("should allow empty blocks", function() {
@@ -171,8 +171,8 @@ describe("processor", function() {
             ].join("\n");
             var blocks = processor.preprocess(code);
 
-            assert.equal(blocks.length, 1);
-            assert.equal(blocks[0], "\n");
+            assert.strictEqual(blocks.length, 1);
+            assert.strictEqual(blocks[0], "\n");
         });
 
         it("should allow whitespace-only blocks", function() {
@@ -187,8 +187,8 @@ describe("processor", function() {
             ].join("\n");
             var blocks = processor.preprocess(code);
 
-            assert.equal(blocks.length, 1);
-            assert.equal(blocks[0], "\n\n \n  \n");
+            assert.strictEqual(blocks.length, 1);
+            assert.strictEqual(blocks[0], "\n\n \n  \n");
         });
 
         it("should ignore code fences with unspecified info string", function() {
@@ -199,7 +199,7 @@ describe("processor", function() {
             ].join("\n");
             var blocks = processor.preprocess(code);
 
-            assert.equal(blocks.length, 0);
+            assert.strictEqual(blocks.length, 0);
         });
 
         it("should find code fences with js info string", function() {
@@ -210,7 +210,7 @@ describe("processor", function() {
             ].join("\n");
             var blocks = processor.preprocess(code);
 
-            assert.equal(blocks.length, 1);
+            assert.strictEqual(blocks.length, 1);
         });
 
         it("should find code fences with javascript info string", function() {
@@ -221,7 +221,7 @@ describe("processor", function() {
             ].join("\n");
             var blocks = processor.preprocess(code);
 
-            assert.equal(blocks.length, 1);
+            assert.strictEqual(blocks.length, 1);
         });
 
         it("should find code fences with node info string", function() {
@@ -232,7 +232,7 @@ describe("processor", function() {
             ].join("\n");
             var blocks = processor.preprocess(code);
 
-            assert.equal(blocks.length, 1);
+            assert.strictEqual(blocks.length, 1);
         });
 
         it("should find code fences with jsx info string", function() {
@@ -243,7 +243,7 @@ describe("processor", function() {
             ].join("\n");
             var blocks = processor.preprocess(code);
 
-            assert.equal(blocks.length, 1);
+            assert.strictEqual(blocks.length, 1);
         });
 
         it("should find code fences ignoring info string case", function() {
@@ -254,7 +254,7 @@ describe("processor", function() {
             ].join("\n");
             var blocks = processor.preprocess(code);
 
-            assert.equal(blocks.length, 1);
+            assert.strictEqual(blocks.length, 1);
         });
 
         it("should ignore anything after the first word of the info string", function() {
@@ -265,7 +265,7 @@ describe("processor", function() {
             ].join("\n");
             var blocks = processor.preprocess(code);
 
-            assert.equal(blocks.length, 1);
+            assert.strictEqual(blocks.length, 1);
         });
 
         it("should find code fences not surrounded by blank lines", function() {
@@ -281,7 +281,7 @@ describe("processor", function() {
             ].join("\n");
             var blocks = processor.preprocess(code);
 
-            assert.equal(blocks.length, 2);
+            assert.strictEqual(blocks.length, 2);
         });
 
         it("should return the source code in the block", function() {
@@ -292,7 +292,7 @@ describe("processor", function() {
             ].join("\n");
             var blocks = processor.preprocess(code);
 
-            assert.equal(blocks[0], "var answer = 6 * 7;\n");
+            assert.strictEqual(blocks[0], "var answer = 6 * 7;\n");
         });
 
         it("should allow multi-line source code", function() {
@@ -304,7 +304,7 @@ describe("processor", function() {
             ].join("\n");
             var blocks = processor.preprocess(code);
 
-            assert.equal(blocks[0], "var answer = 6 * 7;\nconsole.log(answer);\n");
+            assert.strictEqual(blocks[0], "var answer = 6 * 7;\nconsole.log(answer);\n");
         });
 
         it("should preserve original line endings", function() {
@@ -316,7 +316,7 @@ describe("processor", function() {
             ].join("\r\n");
             var blocks = processor.preprocess(code);
 
-            assert.equal(blocks[0], "var answer = 6 * 7;\nconsole.log(answer);\n");
+            assert.strictEqual(blocks[0], "var answer = 6 * 7;\nconsole.log(answer);\n");
         });
 
         it("should unindent space-indented code fences", function() {
@@ -329,7 +329,7 @@ describe("processor", function() {
             ].join("\n");
             var blocks = processor.preprocess(code);
 
-            assert.equal(blocks[0], "var answer = 6 * 7;\n  console.log(answer);\n// Fin.\n");
+            assert.strictEqual(blocks[0], "var answer = 6 * 7;\n  console.log(answer);\n// Fin.\n");
         });
 
         it("should find multiple code fences", function() {
@@ -348,9 +348,9 @@ describe("processor", function() {
             ].join("\n");
             var blocks = processor.preprocess(code);
 
-            assert.equal(blocks.length, 2);
-            assert.equal(blocks[0], "var answer = 6 * 7;\n");
-            assert.equal(blocks[1], "console.log(answer);\n");
+            assert.strictEqual(blocks.length, 2);
+            assert.strictEqual(blocks[0], "var answer = 6 * 7;\n");
+            assert.strictEqual(blocks[1], "console.log(answer);\n");
         });
 
         it("should insert leading configuration comments", function() {
@@ -369,8 +369,8 @@ describe("processor", function() {
             ].join("\n");
             var blocks = processor.preprocess(code);
 
-            assert.equal(blocks.length, 1);
-            assert.equal(blocks[0], [
+            assert.strictEqual(blocks.length, 1);
+            assert.strictEqual(blocks[0], [
                 "/* eslint-env browser */",
                 "/*",
                 "    eslint quotes: [",
@@ -394,8 +394,8 @@ describe("processor", function() {
             ].join("\n");
             var blocks = processor.preprocess(code);
 
-            assert.equal(blocks.length, 1);
-            assert.equal(blocks[0], [
+            assert.strictEqual(blocks.length, 1);
+            assert.strictEqual(blocks[0], [
                 "/* global foo */",
                 "/* global bar:false, baz:true */",
                 "alert(foo, bar, baz);",
@@ -414,8 +414,8 @@ describe("processor", function() {
             ].join("\n");
             var blocks = processor.preprocess(code);
 
-            assert.equal(blocks.length, 1);
-            assert.equal(blocks[0], [
+            assert.strictEqual(blocks.length, 1);
+            assert.strictEqual(blocks[0], [
                 "alert('Hello, world!');",
                 ""
             ].join("\n"));
@@ -432,8 +432,8 @@ describe("processor", function() {
             ].join("\n");
             var blocks = processor.preprocess(code);
 
-            assert.equal(blocks.length, 1);
-            assert.equal(blocks[0], [
+            assert.strictEqual(blocks.length, 1);
+            assert.strictEqual(blocks[0], [
                 "alert('Hello, world!');",
                 ""
             ].join("\n"));
@@ -451,7 +451,7 @@ describe("processor", function() {
                 ].join("\n");
                 var blocks = processor.preprocess(code);
 
-                assert.equal(blocks.length, 0);
+                assert.strictEqual(blocks.length, 0);
             });
 
             it("should skip only one block", function() {
@@ -468,8 +468,8 @@ describe("processor", function() {
                 ].join("\n");
                 var blocks = processor.preprocess(code);
 
-                assert.equal(blocks.length, 1);
-                assert.equal(blocks[0], "var answer = 6 * 7;\n");
+                assert.strictEqual(blocks.length, 1);
+                assert.strictEqual(blocks[0], "var answer = 6 * 7;\n");
             });
 
             it("should still work surrounded by other comments", function() {
@@ -488,8 +488,8 @@ describe("processor", function() {
                 ].join("\n");
                 var blocks = processor.preprocess(code);
 
-                assert.equal(blocks.length, 1);
-                assert.equal(blocks[0], "var answer = 6 * 7;\n");
+                assert.strictEqual(blocks.length, 1);
+                assert.strictEqual(blocks[0], "var answer = 6 * 7;\n");
             });
 
         });
@@ -546,53 +546,53 @@ describe("processor", function() {
         it("should allow for no messages", function() {
             var result = processor.postprocess([[], [], []]);
 
-            assert.equal(result.length, 0);
+            assert.strictEqual(result.length, 0);
         });
 
         it("should flatten messages", function() {
             var result = processor.postprocess(messages);
 
-            assert.equal(result.length, 5);
-            assert.equal(result[0].message, "Use the global form of \"use strict\".");
-            assert.equal(result[1].message, "Unexpected console statement.");
-            assert.equal(result[2].message, "Missing trailing comma.");
-            assert.equal(result[3].message, "Unreachable code after return.");
-            assert.equal(result[4].message, "Unnecessary semicolon.");
+            assert.strictEqual(result.length, 5);
+            assert.strictEqual(result[0].message, "Use the global form of \"use strict\".");
+            assert.strictEqual(result[1].message, "Unexpected console statement.");
+            assert.strictEqual(result[2].message, "Missing trailing comma.");
+            assert.strictEqual(result[3].message, "Unreachable code after return.");
+            assert.strictEqual(result[4].message, "Unnecessary semicolon.");
         });
 
         it("should translate line numbers", function() {
             var result = processor.postprocess(messages);
 
-            assert.equal(result[0].line, 4);
-            assert.equal(result[1].line, 6);
-            assert.equal(result[2].line, 17);
-            assert.equal(result[3].line, 26);
-            assert.equal(result[4].line, 27);
+            assert.strictEqual(result[0].line, 4);
+            assert.strictEqual(result[1].line, 6);
+            assert.strictEqual(result[2].line, 17);
+            assert.strictEqual(result[3].line, 26);
+            assert.strictEqual(result[4].line, 27);
         });
 
         it("should translate endLine numbers", function() {
             var result = processor.postprocess(messages);
 
-            assert.equal(result[0].endLine, 4);
-            assert.equal(result[1].endLine, 6);
-            assert.equal(result[2].endLine, 17);
-            assert.equal(result[3].endLine, 29);
-            assert.equal(result[4].endLine, 27);
+            assert.strictEqual(result[0].endLine, 4);
+            assert.strictEqual(result[1].endLine, 6);
+            assert.strictEqual(result[2].endLine, 17);
+            assert.strictEqual(result[3].endLine, 29);
+            assert.strictEqual(result[4].endLine, 27);
         });
 
         it("should translate column numbers", function() {
             var result = processor.postprocess(messages);
 
-            assert.equal(result[0].column, 1);
-            assert.equal(result[1].column, 5);
+            assert.strictEqual(result[0].column, 1);
+            assert.strictEqual(result[1].column, 5);
         });
 
         it("should translate indented column numbers", function() {
             var result = processor.postprocess(messages);
 
-            assert.equal(result[2].column, 9);
-            assert.equal(result[3].column, 2);
-            assert.equal(result[4].column, 2);
+            assert.strictEqual(result[2].column, 9);
+            assert.strictEqual(result[3].column, 2);
+            assert.strictEqual(result[4].column, 2);
         });
 
         it("should adjust fix range properties", function() {
@@ -611,7 +611,7 @@ describe("processor", function() {
                     ]
                 ]);
 
-                assert.equal(result.length, 0);
+                assert.strictEqual(result.length, 0);
             });
 
             it("unicode-bom", function() {
@@ -621,7 +621,7 @@ describe("processor", function() {
                     ]
                 ]);
 
-                assert.equal(result.length, 0);
+                assert.strictEqual(result.length, 0);
             });
 
         });
@@ -630,7 +630,7 @@ describe("processor", function() {
 
     describe("supportsAutofix", function() {
         it("should equal true", function() {
-            assert.equal(processor.supportsAutofix, true);
+            assert.strictEqual(processor.supportsAutofix, true);
         });
     });
 


### PR DESCRIPTION
The prior config was still enforcing ES5 coding standards. The earliest supported version of Node.js is 6.14.0, so this lets us use all the nice ES6 features.

I split this into multiple commits to ease review:

- b90a6d6 is just `npm install`ing the right versions.
- 02ce704 was done entirely with `npm run lint -- --fix`.
- 24fb9b7 was a bulk find replace `assert.equal` to `assert.strictEqual`.
- 6ca28b5 narrowed variable declaration scope where possible.
- 2612d95 took advantage of the array spread operator.