### PR TITLE
Fix: Support autofix at the very start of blocks

### DIFF
--- a/lib/processor.js
+++ b/lib/processor.js
@@ -274,7 +274,7 @@ function adjustBlock(block) {
                     // then going back one.
                     let i = 1;
 
-                    while (i < block.rangeMap.length && block.rangeMap[i].js < range) {
+                    while (i < block.rangeMap.length && block.rangeMap[i].js <= range) {
                         i++;
                     }
 

--- a/tests/lib/plugin.js
+++ b/tests/lib/plugin.js
@@ -320,6 +320,27 @@ describe("plugin", () => {
             assert.strictEqual(actual, expected);
         });
 
+        it("at the very start of a block", () => {
+            const input = [
+                "This is Markdown.",
+                "",
+                "```js",
+                "'use strict'",
+                "```"
+            ].join("\n");
+            const expected = [
+                "This is Markdown.",
+                "",
+                "```js",
+                "\"use strict\"",
+                "```"
+            ].join("\n");
+            const report = cli.executeOnText(input, "test.md");
+            const actual = report.results[0].output;
+
+            assert.strictEqual(actual, expected);
+        });
+
         it("in blocks with uncommon tags", () => {
             const input = [
                 "This is Markdown.",


### PR DESCRIPTION
Previously, if a rule added an autofix at index 0 of a code block, all
code from the start of the markdown file until the start of that code
block would be removed. Now, the autofix is applied as expected.

Fixes lydell/eslint-plugin-simple-import-sort#22