### PR TITLE
Chore: Add failing test case for indent of multiline fixes

### DIFF
--- a/tests/lib/plugin.js
+++ b/tests/lib/plugin.js
@@ -554,6 +554,52 @@ describe("plugin", () => {
                 assert.strictEqual(actual, expected);
             });
 
+            it("multiline autofix", () => {
+                const input = [
+                    "This is Markdown.",
+                    "",
+                    "   ```js",
+                    "   console.log('Hello, \\",
+                    "   world!')",
+                    "   ```"
+                ].join("\n");
+                const expected = [
+                    "This is Markdown.",
+                    "",
+                    "   ```js",
+                    "   console.log(\"Hello, \\",
+                    "   world!\")",
+                    "   ```"
+                ].join("\n");
+                const report = cli.executeOnText(input, "test.md");
+                const actual = report.results[0].output;
+
+                assert.strictEqual(actual, expected);
+            });
+
+            it("multiline autofix in blockquote", () => {
+                const input = [
+                    "This is Markdown.",
+                    "",
+                    ">   ```js",
+                    ">   console.log('Hello, \\",
+                    ">   world!')",
+                    ">   ```"
+                ].join("\n");
+                const expected = [
+                    "This is Markdown.",
+                    "",
+                    ">   ```js",
+                    ">   console.log(\"Hello, \\",
+                    ">   world!\")",
+                    ">   ```"
+                ].join("\n");
+                const report = cli.executeOnText(input, "test.md");
+                const actual = report.results[0].output;
+
+                assert.strictEqual(actual, expected);
+            });
+
             it("by one space with comments", () => {
                 const input = [
                     "This is Markdown.",


### PR DESCRIPTION
If the replacement text of an autofix contains newlines, all lines but
the first in the replacement text will unexpectedly have 0 indentation
if a code block is indented. I guess not only the _range_ of fixes but
also the _text_ of fixes need to be adjusted.

If the code block is placed within a blockquote, a `>` character also
needs to be inserted.

This issue was found while investigating
lydell/eslint-plugin-simple-import-sort#22. That plugin fixes several lines
of imports in one go. This means that most of the imports will have too
little indentation after autofix if the code block is indented (such as
when placed in a list).