### PR TITLE
Fix: Indent multiline fixes (fixes #120)

### DIFF
--- a/lib/processor.js
+++ b/lib/processor.js
@@ -65,7 +65,33 @@ function getComment(html) {
     return comment;
 }
 
-const leadingWhitespaceRegex = /^\s*/;
+// Before a code block, blockquote characters (`>`) are also considered
+// "whitespace".
+const leadingWhitespaceRegex = /^[>\s]*/;
+
+/**
+ * Gets the offset for the first column of the node's first line in the
+ * original source text.
+ * @param {ASTNode} node A Markdown code block AST node.
+ * @returns {number} The offset for the first column of the node's first line.
+ */
+function getBeginningOfLineOffset(node) {
+    return node.position.start.offset - node.position.start.column + 1;
+}
+
+/**
+ * Gets the leading text, typically whitespace with possible blockquote chars,
+ * used to indent a code block.
+ * @param {string} text The text of the file.
+ * @param {ASTNode} node A Markdown code block AST node.
+ * @returns {string} The text from the start of the first line to the opening
+ *     fence of the code block.
+ */
+function getIndentText(text, node) {
+    return leadingWhitespaceRegex.exec(
+        text.slice(getBeginningOfLineOffset(node))
+    )[0];
+}
 
 /**
  * When applying fixes, the postprocess step needs to know how to map fix ranges
@@ -110,7 +136,7 @@ function getBlockRangeMap(text, node, comments) {
      * additional indenting, the opening fence's first backtick may be up to
      * three whitespace characters after the start offset.
      */
-    const startOffset = node.position.start.offset;
+    const startOffset = getBeginningOfLineOffset(node);
 
     /*
      * Extract the Markdown source to determine the leading whitespace for each
@@ -125,8 +151,7 @@ function getBlockRangeMap(text, node, comments) {
      * backtick's column is the AST node's starting column plus any additional
      * indentation.
      */
-    const baseIndent = node.position.start.column - 1 +
-        leadingWhitespaceRegex.exec(lines[0])[0].length;
+    const baseIndent = getIndentText(text, node).length;
 
     /*
      * Track the length of any inserted configuration comments at the beginning
@@ -182,6 +207,7 @@ function getBlockRangeMap(text, node, comments) {
         mdOffset += line.length + 1;
         jsOffset += line.length - trimLength + 1;
     }
+
     return rangeMap;
 }
 
@@ -219,6 +245,7 @@ function preprocess(text) {
                 }
 
                 blocks.push(assign({}, node, {
+                    baseIndentText: getIndentText(text, node),
                     comments,
                     rangeMap: getBlockRangeMap(text, node, comments)
                 }));
@@ -281,7 +308,7 @@ function adjustBlock(block) {
                     // Apply the mapping delta for this range.
                     return range + block.rangeMap[i - 1].md;
                 }),
-                text: message.fix.text
+                text: message.fix.text.replace("\n", `\n${block.baseIndentText}`)
             };
         }
 

--- a/tests/lib/plugin.js
+++ b/tests/lib/plugin.js
@@ -590,6 +590,11 @@ describe("plugin", () => {
                     "     console.log('Hello, world!')",
                     "   ```"
                 ].join("\n");
+
+                // The Markdown parser doesn't have any concept of a "negative"
+                // indent left of the opening code fence, so autofixes move
+                // lines that were previously underindented to the same level
+                // as the opening code fence.
                 const expected = [
                     "   ```js",
                     " console.log(\"Hello, world!\")",
@@ -644,6 +649,11 @@ describe("plugin", () => {
                     "> >    world!')",
                     "> >   ```"
                 ].join("\n");
+
+                // The Markdown parser doesn't have any concept of a "negative"
+                // indent left of the opening code fence, so autofixes move
+                // lines that were previously underindented to the same level
+                // as the opening code fence.
                 const expected = [
                     "This is Markdown.",
                     "",

--- a/tests/lib/plugin.js
+++ b/tests/lib/plugin.js
@@ -554,6 +554,52 @@ describe("plugin", () => {
                 assert.strictEqual(actual, expected);
             });
 
+            it("multiline autofix", () => {
+                const input = [
+                    "This is Markdown.",
+                    "",
+                    "   ```js",
+                    "   console.log('Hello, \\",
+                    "   world!')",
+                    "   ```"
+                ].join("\n");
+                const expected = [
+                    "This is Markdown.",
+                    "",
+                    "   ```js",
+                    "   console.log(\"Hello, \\",
+                    "   world!\")",
+                    "   ```"
+                ].join("\n");
+                const report = cli.executeOnText(input, "test.md");
+                const actual = report.results[0].output;
+
+                assert.strictEqual(actual, expected);
+            });
+
+            it("multiline autofix in blockquote", () => {
+                const input = [
+                    "This is Markdown.",
+                    "",
+                    ">   ```js",
+                    ">   console.log('Hello, \\",
+                    ">   world!')",
+                    ">   ```"
+                ].join("\n");
+                const expected = [
+                    "This is Markdown.",
+                    "",
+                    ">   ```js",
+                    ">   console.log(\"Hello, \\",
+                    ">   world!\")",
+                    ">   ```"
+                ].join("\n");
+                const report = cli.executeOnText(input, "test.md");
+                const actual = report.results[0].output;
+
+                assert.strictEqual(actual, expected);
+            });
+
             it("by one space with comments", () => {
                 const input = [
                     "This is Markdown.",

--- a/tests/lib/plugin.js
+++ b/tests/lib/plugin.js
@@ -631,6 +631,37 @@ describe("plugin", () => {
                 assert.strictEqual(actual, expected);
             });
 
+            it("multiline autofix in nested blockquote", () => {
+                const input = [
+                    "This is Markdown.",
+                    "",
+                    "> This is a nested blockquote.",
+                    ">",
+                    "> >   ```js",
+                    "> >  console.log('Hello, \\",
+                    "> > world!')",
+                    "> >  console.log('Hello, \\",
+                    "> >    world!')",
+                    "> >   ```"
+                ].join("\n");
+                const expected = [
+                    "This is Markdown.",
+                    "",
+                    "> This is a nested blockquote.",
+                    ">",
+                    "> >   ```js",
+                    "> >  console.log(\"Hello, \\",
+                    "> >   world!\")",
+                    "> >  console.log(\"Hello, \\",
+                    "> >    world!\")",
+                    "> >   ```"
+                ].join("\n");
+                const report = cli.executeOnText(input, "test.md");
+                const actual = report.results[0].output;
+
+                assert.strictEqual(actual, expected);
+            });
+
             it("by one space with comments", () => {
                 const input = [
                     "This is Markdown.",

--- a/tests/lib/plugin.js
+++ b/tests/lib/plugin.js
@@ -561,6 +561,8 @@ describe("plugin", () => {
                     "   ```js",
                     "   console.log('Hello, \\",
                     "   world!')",
+                    "   console.log('Hello, \\",
+                    "   world!')",
                     "   ```"
                 ].join("\n");
                 const expected = [
@@ -569,6 +571,31 @@ describe("plugin", () => {
                     "   ```js",
                     "   console.log(\"Hello, \\",
                     "   world!\")",
+                    "   console.log(\"Hello, \\",
+                    "   world!\")",
+                    "   ```"
+                ].join("\n");
+                const report = cli.executeOnText(input, "test.md");
+                const actual = report.results[0].output;
+
+                assert.strictEqual(actual, expected);
+            });
+
+            it("underindented multiline autofix", () => {
+                const input = [
+                    "   ```js",
+                    " console.log('Hello, world!')",
+                    "  console.log('Hello, \\",
+                    "  world!')",
+                    "     console.log('Hello, world!')",
+                    "   ```"
+                ].join("\n");
+                const expected = [
+                    "   ```js",
+                    " console.log(\"Hello, world!\")",
+                    "  console.log(\"Hello, \\",
+                    "   world!\")",
+                    "     console.log(\"Hello, world!\")",
                     "   ```"
                 ].join("\n");
                 const report = cli.executeOnText(input, "test.md");
@@ -584,12 +611,16 @@ describe("plugin", () => {
                     ">   ```js",
                     ">   console.log('Hello, \\",
                     ">   world!')",
+                    ">   console.log('Hello, \\",
+                    ">   world!')",
                     ">   ```"
                 ].join("\n");
                 const expected = [
                     "This is Markdown.",
                     "",
                     ">   ```js",
+                    ">   console.log(\"Hello, \\",
+                    ">   world!\")",
                     ">   console.log(\"Hello, \\",
                     ">   world!\")",
                     ">   ```"


### PR DESCRIPTION
Thanks to @lydell for discovering this bug and writing the tests to reproduce it in #120.

If I lint the following Markdown source text containing a JS code block inside a blockquote:

````md
This is Markdown.

>   ```js
>   console.log('Hello, \
>   world!');
>   ```
````

What ESLint sees is this:

```js
console.log('Hello, \
world!');
```

The fix text sent to the processor will contain the string, now with double quotes, and preserving the newline as-is:

```
"Hello, \\\nworld!"
```

The fix would then be applied incorrectly because it didn't account for the leading `>   ` in the Markdown source text:

````md
This is Markdown.

>   ```js
>   console.log("Hello, \
world!" world!');
>   ```
````

This change tracks the leading text that precedes the first line of any fenced code block and inserts the same prefix after any newline in a fix, so the fix text in the above example would become:
```
"Hello, \\\n>   world!"
````