### PR TITLE
Upgrade: Update devDeps and change istanbul -> nyc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ coverage/
 node_modules/
 npm-debug.log
 .eslint-release-info.json
+.nyc_output

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "lint": "eslint .",
     "test": "npm run lint && npm run test-cov",
-    "test-cov": "istanbul cover _mocha -- -c tests/lib/**/*.js",
+    "test-cov": "nyc _mocha -- -c tests/lib/**/*.js",
     "generate-release": "eslint-generate-release",
     "generate-alpharelease": "eslint-generate-prerelease alpha",
     "generate-betarelease": "eslint-generate-prerelease beta",
@@ -36,13 +36,13 @@
     "lib/processor.js"
   ],
   "devDependencies": {
-    "chai": "^3.0.0",
-    "eslint": "^4.19.1",
+    "chai": "^4.2.0",
+    "eslint": "^5.16.0",
     "eslint-config-eslint": "^5.0.1",
     "eslint-plugin-node": "^6.0.1",
-    "eslint-release": "^1.0.0",
-    "istanbul": "^0.4.5",
-    "mocha": "^2.2.5"
+    "eslint-release": "^1.2.0",
+    "mocha": "^6.2.2",
+    "nyc": "^14.1.1"
   },
   "dependencies": {
     "object-assign": "^4.0.1",

--- a/tests/lib/plugin.js
+++ b/tests/lib/plugin.js
@@ -20,6 +20,7 @@ function initCLI(isAutofixEnabled) {
     const cli = new CLIEngine({
         envs: ["browser"],
         extensions: ["md", "mkdn", "mdown", "markdown"],
+        plugins: ["markdown"],
         fix,
         ignore: false,
         rules: {


### PR DESCRIPTION
Upgrade: Update devDeps and change istanbul -> nyc

Update eslint-release, chai, mocha, eslint devDeps. In process of updating,
get plugins tests to work in anticipation of eslint 6.

Note that this still doesn't include logic to exclude ESLint 6 in Node 6 on Travis (or, if you preferred, to bump `engines` to 8.10.0 and drop Travis testing of 6).

If you like, I can also upgrade the deps. to the versions prior to breaking.