### PR TITLE
Feat: Add typescript support

### DIFF
--- a/lib/processor.js
+++ b/lib/processor.js
@@ -9,7 +9,7 @@ const assign = require("object-assign");
 const unified = require("unified");
 const remarkParse = require("remark-parse");
 
-const SUPPORTED_SYNTAXES = ["js", "javascript", "node", "jsx"];
+const SUPPORTED_SYNTAXES = ["js", "javascript", "node", "jsx", "ts", "typescript"];
 const UNSATISFIABLE_RULES = [
     "eol-last", // The Markdown parser strips trailing newlines in code fences
     "unicode-bom" // Code blocks will begin in the middle of Markdown files


### PR DESCRIPTION
Hi,

I tested a rc version on a [custom repo](https://www.npmjs.com/@getstation/eslint-plugin-markdown) and it seems to work fine (tested with eslint@6.8.0)

Let me know if something is missing