### PR TITLE
Chore: Use ES2018 object spread syntax

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,6 +14,10 @@ if (!fs.existsSync(SYMLINK_LOCATION)) {
 module.exports = {
     "root": true,
 
+    "parserOptions": {
+        "ecmaVersion": 2018
+    },
+
     "plugins": [
         PACKAGE_NAME
     ],

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -5,7 +5,6 @@
 
 "use strict";
 
-const assign = require("object-assign");
 const unified = require("unified");
 const remarkParse = require("remark-parse");
 
@@ -244,11 +243,12 @@ function preprocess(text) {
                     previousNode = parent.children[index];
                 }
 
-                blocks.push(assign({}, node, {
+                blocks.push({
+                    ...node,
                     baseIndentText: getIndentText(text, node),
                     comments,
                     rangeMap: getBlockRangeMap(text, node, comments)
-                }));
+                });
             }
         }
     });
@@ -312,7 +312,7 @@ function adjustBlock(block) {
             };
         }
 
-        return assign({}, message, out, adjustedFix);
+        return { ...message, ...out, ...adjustedFix };
     };
 }
 

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "nyc": "^14.1.1"
   },
   "dependencies": {
-    "object-assign": "^4.0.1",
     "remark-parse": "^5.0.0",
     "unified": "^6.1.2"
   },


### PR DESCRIPTION
This syntax first shipped in Node.js v8.6.0 and removes a dependency on `object-assign`.