### PR TITLE
Breaking: Require ESLint v6

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   ],
   "devDependencies": {
     "chai": "^4.2.0",
-    "eslint": "^5.16.0",
+    "eslint": "^6.8.0",
     "eslint-config-eslint": "^5.0.1",
     "eslint-plugin-node": "^6.0.1",
     "eslint-release": "^1.2.0",
@@ -48,6 +48,9 @@
     "object-assign": "^4.0.1",
     "remark-parse": "^5.0.0",
     "unified": "^6.1.2"
+  },
+  "peerDependencies": {
+    "eslint": ">=6.0.0"
   },
   "engines": {
     "node": "^8.10.0 || ^10.12.0 || >= 12.0.0"


### PR DESCRIPTION
The new processor API shipped in ESLint v6.

Is there any reason the peer dependency would cause trouble? It was removed back in #40 because it had issues with a prerelease. npm doesn't consider `v7.0.0-alpha.1` to satisfy `>=6.0.0`, but if I install `eslint@7.0.0-alpha.1` on top of this commit, I get a warning that the `eslint@>=6.0.0` peer dependency is unmet, yet it doesn't appear to break anything.