### PR TITLE
Chore: Update ESLint config and plugins

### DIFF
--- a/lib/processor.js
+++ b/lib/processor.js
@@ -46,7 +46,7 @@ function traverse(node, callbacks, parent) {
 function getComment(html) {
     const commentStart = "<!--";
     const commentEnd = "-->";
-    const regex = /^(eslint\b|global\s)/;
+    const regex = /^(eslint\b|global\s)/u;
 
     if (
         html.slice(0, commentStart.length) !== commentStart ||
@@ -66,7 +66,7 @@ function getComment(html) {
 
 // Before a code block, blockquote characters (`>`) are also considered
 // "whitespace".
-const leadingWhitespaceRegex = /^[>\s]*/;
+const leadingWhitespaceRegex = /^[>\s]*/u;
 
 /**
  * Gets the offset for the first column of the node's first line in the
@@ -115,7 +115,6 @@ function getIndentText(text, node) {
  * suffix of the corresponding line in the Markdown code block. There are no
  * differences within the line, so the mapping need only provide the offset
  * delta at the beginning of each line.
- *
  * @param {string} text The text of the file.
  * @param {ASTNode} node A Markdown code block AST node.
  * @param {comments} comments List of configuration comment strings that will be
@@ -308,7 +307,7 @@ function adjustBlock(block) {
                     // Apply the mapping delta for this range.
                     return range + block.rangeMap[i - 1].md;
                 }),
-                text: message.fix.text.replace(/\n/g, `\n${block.baseIndentText}`)
+                text: message.fix.text.replace(/\n/gu, `\n${block.baseIndentText}`)
             };
         }
 

--- a/package.json
+++ b/package.json
@@ -38,8 +38,9 @@
   "devDependencies": {
     "chai": "^4.2.0",
     "eslint": "^6.8.0",
-    "eslint-config-eslint": "^5.0.1",
-    "eslint-plugin-node": "^6.0.1",
+    "eslint-config-eslint": "^6.0.0",
+    "eslint-plugin-jsdoc": "^15.9.5",
+    "eslint-plugin-node": "^9.0.0",
     "eslint-release": "^1.2.0",
     "mocha": "^6.2.2",
     "nyc": "^14.1.1"


### PR DESCRIPTION
This matches ESLint configuration as of the last v6 release. Since this only affects devDependencies, it's a chore rather than an upgrade tag.

`require-unicode-regexp` was the only rule that required code changes.