### PR TITLE
New: Add recommended config (fixes #151)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,17 @@ npm install --save-dev eslint eslint-plugin-markdown@next
 
 ### Configuring
 
+Extending the `plugin:markdown/recommended` config will enable the Markdown processor on all `.md` files:
+
+```js
+// .eslintrc.js
+module.exports = {
+    extends: "plugin:markdown/recommended"
+};
+```
+
+#### Advanced Configuration
+
 Add the plugin to your `.eslintrc` and use the `processor` option in an `overrides` entry to enable the plugin's `markdown/markdown` processor on Markdown files.
 Each fenced code block inside a Markdown document has a virtual filename appended to the Markdown file's path.
 The virtual filename's extension will match the fenced code block's syntax tag, so for example, <code>```js</code> code blocks in <code>README.md</code> would match <code>README.md/*.js</code>.

--- a/index.js
+++ b/index.js
@@ -5,6 +5,4 @@
 
 "use strict";
 
-// https://github.com/mysticatea/eslint-plugin-node/issues/193
-// eslint-disable-next-line node/no-unpublished-require
 module.exports = require("./lib");

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,6 +8,17 @@
 const processor = require("./processor");
 
 module.exports = {
+    configs: {
+        recommended: {
+            plugins: ["markdown"],
+            overrides: [
+                {
+                    files: ["*.md"],
+                    processor: "markdown/markdown"
+                }
+            ]
+        }
+    },
     processors: {
         markdown: processor
     }

--- a/tests/fixtures/recommended.json
+++ b/tests/fixtures/recommended.json
@@ -1,0 +1,7 @@
+{
+    "root": true,
+    "extends": "plugin:markdown/recommended",
+    "rules": {
+        "no-console": "error"
+    }
+}

--- a/tests/lib/plugin.js
+++ b/tests/lib/plugin.js
@@ -6,27 +6,81 @@
 "use strict";
 
 const assert = require("chai").assert;
+const execSync = require("child_process").execSync;
 const CLIEngine = require("eslint").CLIEngine;
 const path = require("path");
 const plugin = require("../..");
 
 /**
  * Helper function which creates CLIEngine instance with enabled/disabled autofix feature.
+ * @param {string} fixtureConfigName ESLint JSON config fixture filename.
  * @param {boolean} [isAutofixEnabled=false] Whether to enable autofix feature.
  * @returns {CLIEngine} CLIEngine instance to execute in tests.
  */
-function initCLI(isAutofixEnabled) {
+function initCLI(fixtureConfigName, isAutofixEnabled) {
     const fix = isAutofixEnabled || false;
     const cli = new CLIEngine({
         fix,
         ignore: false,
         useEslintrc: false,
-        configFile: path.resolve(__dirname, "../fixtures/eslintrc.json")
+        configFile: path.resolve(__dirname, "../fixtures/", fixtureConfigName)
     });
 
     cli.addPlugin("markdown", plugin);
     return cli;
 }
+
+describe("recommended config", () => {
+
+    let cli;
+    const shortText = [
+        "```js",
+        "console.log(42);",
+        "```"
+    ].join("\n");
+
+    before(function() {
+        try {
+
+            // The tests for the recommended config will have ESLint import
+            // the plugin, so we need to make sure it's resolvable and link it
+            // if not.
+            // eslint-disable-next-line node/no-extraneous-require
+            require.resolve("eslint-plugin-markdown");
+        } catch (error) {
+            if (error.code === "MODULE_NOT_FOUND") {
+
+                // The npm link step can take longer than Mocha's default 2s
+                // timeout, so give it more time. Mocha's API for customizing
+                // hook-level timeouts uses `this`, so disable the rule.
+                // https://mochajs.org/#hook-level
+                // eslint-disable-next-line no-invalid-this
+                this.timeout(9999);
+
+                execSync("npm link && npm link eslint-plugin-markdown");
+            } else {
+                throw error;
+            }
+        }
+
+        cli = initCLI("recommended.json");
+    });
+
+    it("should include the plugin", () => {
+        const config = cli.getConfigForFile("test.md");
+
+        assert.include(config.plugins, "markdown");
+    });
+
+    it("overrides configure processor to parse .md file code blocks", () => {
+        const report = cli.executeOnText(shortText, "test.md");
+
+        assert.strictEqual(report.results.length, 1);
+        assert.strictEqual(report.results[0].messages.length, 1);
+        assert.strictEqual(report.results[0].messages[0].ruleId, "no-console");
+    });
+
+});
 
 describe("plugin", () => {
 
@@ -38,7 +92,7 @@ describe("plugin", () => {
     ].join("\n");
 
     before(() => {
-        cli = initCLI();
+        cli = initCLI("eslintrc.json");
     });
 
     it("should run on .md files", () => {
@@ -195,7 +249,7 @@ describe("plugin", () => {
     describe("should fix code", () => {
 
         before(() => {
-            cli = initCLI(true);
+            cli = initCLI("eslintrc.json", true);
         });
 
         it("in the simplest case", () => {


### PR DESCRIPTION
Should `plugin:markdown/recommended` enable the processor on just `.md` files or also `.mkdn`, `.mdown`, and `.markdown` (the same file extensions as v1)? I went with just `.md` since overriding to add the other extensions is straightforward, but I could be convinced to include the other three.

Is test coverage adequate? I My thinking was that asserting "it works" is sufficient to say the recommended config is being loaded, and the rest of the plugin tests can handle the details.