### PR TITLE
Fix: Don't require message end locations (fixes #112)

### DIFF
--- a/lib/processor.js
+++ b/lib/processor.js
@@ -279,7 +279,6 @@ function adjustBlock(block) {
     return function adjustMessage(message) {
 
         const lineInCode = message.line - leadingCommentLines;
-        const endLine = message.endLine - leadingCommentLines;
 
         if (lineInCode < 1) {
             return null;
@@ -287,9 +286,12 @@ function adjustBlock(block) {
 
         const out = {
             line: lineInCode + blockStart,
-            endLine: endLine ? endLine + blockStart : endLine,
             column: message.column + block.position.indent[lineInCode - 1] - 1
         };
+
+        if (Number.isInteger(message.endLine)) {
+            out.endLine = message.endLine - leadingCommentLines + blockStart;
+        }
 
         const adjustedFix = {};
 

--- a/tests/lib/plugin.js
+++ b/tests/lib/plugin.js
@@ -72,6 +72,20 @@ describe("plugin", () => {
         assert.strictEqual(report.results[0].messages[1].endLine, 8);
     });
 
+    it("doesn't add end locations to messages without them", () => {
+        const code = [
+            "```js",
+            "!@#$%^&*()",
+            "```"
+        ].join("\n");
+        const report = cli.executeOnText(code, "test.md");
+
+        assert.strictEqual(report.results.length, 1);
+        assert.strictEqual(report.results[0].messages.length, 1);
+        assert.notProperty(report.results[0].messages[0], "endLine");
+        assert.notProperty(report.results[0].messages[0], "endColumn");
+    });
+
     it("should emit correct line numbers with leading comments", () => {
         const code = [
             "# Hello, world!",


### PR DESCRIPTION
Issue #112 reported VSCode drawing squigglies all the way from the top of a file to a line in a code block with a syntax error rather than just squigglying the line with the syntax error. For messages that only specified start locations, the processor was adding `endLine: NaN`.