### PR TITLE
Chore: run CI in Node 14.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ["8.10.0", 8.x, 10.x, 12.x, 13.x]
+        node-version: ["8.10.0", 8.x, 10.x, 12.x, 13.x, 14.x]
     steps:
     - name: Checkout
       uses: actions/checkout@v1


### PR DESCRIPTION
Noticed we aren't running CI in Node 14!