### PR TITLE
Build: Install example test dependencies in Jenkins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,17 +36,7 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - name: Install Packages
-      run: npm install
-      env:
-        CI: true
-    - name: Install examples/react Packages
-      working-directory: ./examples/react
-      run: npm install
-      env:
-        CI: true
-    - name: Install examples/typescript Packages
-      working-directory: ./examples/typescript
-      run: npm install
+      run: npm install && npm run install-examples
       env:
         CI: true
     - name: Test

--- a/package.json
+++ b/package.json
@@ -20,13 +20,14 @@
     "linter"
   ],
   "scripts": {
+    "install-examples": "for example in examples/*; do (cd \"$example\" && npm install); done",
     "lint": "eslint --ext js,md .",
     "test": "npm run lint && npm run test-cov",
     "test-cov": "nyc _mocha -- -c tests/{examples,lib}/**/*.js",
-    "generate-release": "eslint-generate-release",
-    "generate-alpharelease": "eslint-generate-prerelease alpha",
-    "generate-betarelease": "eslint-generate-prerelease beta",
-    "generate-rcrelease": "eslint-generate-prerelease rc",
+    "generate-release": "npm run install-examples && eslint-generate-release",
+    "generate-alpharelease": "npm run install-examples && eslint-generate-prerelease alpha",
+    "generate-betarelease": "npm run install-examples && eslint-generate-prerelease beta",
+    "generate-rcrelease": "npm run install-examples && eslint-generate-prerelease rc",
     "publish-release": "eslint-publish-release"
   },
   "main": "index.js",


### PR DESCRIPTION
The 2.0.0-rc.0 release attempt failed when trying to run the examples' tests because their dependencies were never installed. In #152, I added an install step to the GitHub Actions workflow but not the Jenkins release flow. This change adds an `install-examples` npm script and calls it both from the GitHub Actions workflow and the `generate-.*release` scripts.