### PR TITLE
chore: fix failing tests

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,9 +1,9 @@
 "use strict";
 
-var fs = require("fs");
-var path = require("path");
-var PACKAGE_NAME = require("./package").name;
-var SYMLINK_LOCATION = path.join(__dirname, "node_modules", PACKAGE_NAME);
+const fs = require("fs");
+const path = require("path");
+const PACKAGE_NAME = require("./package").name;
+const SYMLINK_LOCATION = path.join(__dirname, "node_modules", PACKAGE_NAME);
 
 // Symlink node_modules/eslint-plugin-markdown to this directory so that ESLint
 // resolves this plugin name correctly.
@@ -12,37 +12,37 @@ if (!fs.existsSync(SYMLINK_LOCATION)) {
 }
 
 module.exports = {
-    "root": true,
+    root: true,
 
-    "parserOptions": {
-        "ecmaVersion": 2018
+    parserOptions: {
+        ecmaVersion: 2018
     },
 
-    "plugins": [
+    plugins: [
         PACKAGE_NAME
     ],
 
-    "env": {
-        "node": true
+    env: {
+        node: true
     },
 
-    "extends": "eslint",
+    extends: "eslint",
 
-    "ignorePatterns": ["examples"],
+    ignorePatterns: ["examples"],
 
-    "overrides": [
+    overrides: [
         {
-            "files": ["**/*.md"],
-            "processor": "markdown/markdown"
+            files: ["**/*.md"],
+            processor: "markdown/markdown"
         },
         {
-            "files": ["**/*.md/*.js"],
-            "parserOptions": {
-                "ecmaFeatures": {
-                    "impliedStrict": true
+            files: ["**/*.md/*.js"],
+            parserOptions: {
+                ecmaFeatures: {
+                    impliedStrict: true
                 }
             },
-            "rules": {
+            rules: {
                 "lines-around-comment": "off"
             }
         }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ["8.10.0", 8.x, 10.x, 12.x, 13.x, 14.x]
+        node-version: ["10.12.0", 10.x, 12.x, 14.x, 15.x]
     steps:
     - name: Checkout
       uses: actions/checkout@v1
@@ -36,7 +36,7 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - name: Install Packages
-      run: npm install && npm run install-examples
+      run: npm install --legacy-peer-deps && npm run install-examples
       env:
         CI: true
     - name: Test

--- a/package.json
+++ b/package.json
@@ -37,23 +37,27 @@
     "lib/processor.js"
   ],
   "devDependencies": {
+    "@typescript-eslint/eslint-plugin": "^4.6.1",
+    "@typescript-eslint/parser": "^4.6.1",
     "chai": "^4.2.0",
-    "eslint": "^6.8.0",
+    "eslint": "^7.12.1",
     "eslint-config-eslint": "^6.0.0",
-    "eslint-plugin-jsdoc": "^15.9.5",
+    "eslint-plugin-jsdoc": "^30.7.6",
     "eslint-plugin-node": "^9.0.0",
+    "eslint-plugin-react": "^7.21.5",
     "eslint-release": "^1.2.0",
     "mocha": "^6.2.2",
-    "nyc": "^14.1.1"
+    "nyc": "^14.1.1",
+    "typescript": "^4.0.5"
   },
   "dependencies": {
     "remark-parse": "^5.0.0",
     "unified": "^6.1.2"
   },
   "peerDependencies": {
-    "eslint": ">=6.0.0"
+    "eslint": ">=7.0.0"
   },
   "engines": {
-    "node": "^8.10.0 || ^10.12.0 || >= 12.0.0"
+    "node": "^10.12.0 || >= 12.0.0"
   }
 }


### PR DESCRIPTION
Two tests are written that require ESLint@7, but the project specifies
ESLint@6. Move to ESLint@7.

BREAKING CHANGE: ESLint@7 drops support for Node.js 8.x.