### PR TITLE
Chore: Automatically install example dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - name: Install Packages
-      run: npm install && npm run install-examples
+      run: npm install
       env:
         CI: true
     - name: Test

--- a/package.json
+++ b/package.json
@@ -20,14 +20,14 @@
     "linter"
   ],
   "scripts": {
-    "install-examples": "for example in examples/*; do (cd \"$example\" && npm install); done",
     "lint": "eslint --ext js,md .",
+    "prepare": "for example in examples/*; do (cd \"$example\" && npm install); done",
     "test": "npm run lint && npm run test-cov",
     "test-cov": "nyc _mocha -- -c tests/{examples,lib}/**/*.js",
-    "generate-release": "npm run install-examples && eslint-generate-release",
-    "generate-alpharelease": "npm run install-examples && eslint-generate-prerelease alpha",
-    "generate-betarelease": "npm run install-examples && eslint-generate-prerelease beta",
-    "generate-rcrelease": "npm run install-examples && eslint-generate-prerelease rc",
+    "generate-release": "eslint-generate-release",
+    "generate-alpharelease": "eslint-generate-prerelease alpha",
+    "generate-betarelease": "eslint-generate-prerelease beta",
+    "generate-rcrelease": "eslint-generate-prerelease rc",
     "publish-release": "eslint-publish-release"
   },
   "main": "index.js",


### PR DESCRIPTION
Previously, CI was explicitly running the `install-examples` script as its own step. This was also necessary but not documented locally, so `git clone; npm install; npm test` would show a couple failures when the examples inherited the wrong ESLint dependency. The examples' dependencies should now be installed automatically when running `npm install` locally without any arguments.

Originally reported in #163.

**For reviewers:** Based on my reading of https://docs.npmjs.com/cli/v6/using-npm/scripts, this is a safe usage of the `prepare` script, but I'd appreciate a second set of eyes on that. The goal is to run as part of `npm install` locally but not when the plugin is a dependency. The additional runs before packing and publishing are unnecessary but I don't think they should cause a problem. I'll do a `rc.1` release after merging this just to make sure there aren't any unexpected kinks. The fallback plan is just to document the second step.