### PR TITLE
Chore: Switch to main for primary branch (fixes #161)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 jobs:
   lint:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # eslint-plugin-markdown
 
 [![npm Version](https://img.shields.io/npm/v/eslint-plugin-markdown.svg)](https://www.npmjs.com/package/eslint-plugin-markdown)
-[![Build Status](https://img.shields.io/github/workflow/status/eslint/eslint-plugin-markdown/CI/master.svg)](https://github.com/eslint/eslint-plugin-markdown/actions)
+[![Build Status](https://img.shields.io/github/workflow/status/eslint/eslint-plugin-markdown/CI/main.svg)](https://github.com/eslint/eslint-plugin-markdown/actions)
 
 Lint JS, JSX, TypeScript, and more inside Markdown.
 
@@ -12,7 +12,7 @@ Lint JS, JSX, TypeScript, and more inside Markdown.
     alt="A JS code snippet in a Markdown editor has red squiggly underlines. A tooltip explains the problem."
 />
 
-> 🚧 This documentation is for an unfinished v2 release in progress in the `master` branch. The latest stable documentation is in the [`v1` branch](https://github.com/eslint/eslint-plugin-markdown/tree/v1).
+> 🚧 This documentation is for an unfinished v2 release in progress in the `main` branch. The latest stable documentation is in the [`v1` branch](https://github.com/eslint/eslint-plugin-markdown/tree/v1).
 
 ## Usage
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "eslint-config-eslint": "^6.0.0",
     "eslint-plugin-jsdoc": "^15.9.5",
     "eslint-plugin-node": "^9.0.0",
-    "eslint-release": "^1.2.0",
+    "eslint-release": "^3.1.2",
     "mocha": "^6.2.2",
     "nyc": "^14.1.1"
   },


### PR DESCRIPTION
The only remaining string search results for "master" are URLs to other repositories.