### PR TITLE
Fix: Ignore words in info string after syntax (fixes #166)

### DIFF
--- a/lib/processor.js
+++ b/lib/processor.js
@@ -252,7 +252,9 @@ function preprocess(text) {
     });
 
     return blocks.map((block, index) => ({
-        filename: `${index}.${block.lang.trimStart().split(" ")[0]}`,
+
+        // TODO: Use trimStart() after dropping Node.js 8.x support.
+        filename: `${index}.${block.lang.replace(/^\s+/u, "").split(" ")[0]}`,
         text: [
             ...block.comments,
             block.value,

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -252,7 +252,7 @@ function preprocess(text) {
     });
 
     return blocks.map((block, index) => ({
-        filename: `${index}.${block.lang}`,
+        filename: `${index}.${block.lang.trimStart().split(" ")[0]}`,
         text: [
             ...block.comments,
             block.value,

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -252,9 +252,7 @@ function preprocess(text) {
     });
 
     return blocks.map((block, index) => ({
-
-        // TODO: Use trimStart() after dropping Node.js 8.x support.
-        filename: `${index}.${block.lang.replace(/^\s+/u, "").split(" ")[0]}`,
+        filename: `${index}.${block.lang.trim().split(" ")[0]}`,
         text: [
             ...block.comments,
             block.value,

--- a/tests/lib/processor.js
+++ b/tests/lib/processor.js
@@ -297,6 +297,18 @@ describe("processor", () => {
             assert.strictEqual(blocks[0].filename, "0.js");
         });
 
+        it("should ignore trailing whitespace in the info string", () => {
+            const code = [
+                "```js    ",
+                "var answer = 6 * 7;",
+                "```"
+            ].join("\n");
+            const blocks = processor.preprocess(code);
+
+            assert.strictEqual(blocks.length, 1);
+            assert.strictEqual(blocks[0].filename, "0.js");
+        });
+
         it("should find code fences not surrounded by blank lines", () => {
             const code = [
                 "<!-- eslint-disable -->",

--- a/tests/lib/processor.js
+++ b/tests/lib/processor.js
@@ -222,6 +222,7 @@ describe("processor", () => {
             const blocks = processor.preprocess(code);
 
             assert.strictEqual(blocks.length, 1);
+            assert.strictEqual(blocks[0].filename, "0.js");
         });
 
         it("should find code fences with javascript info string", () => {
@@ -233,6 +234,7 @@ describe("processor", () => {
             const blocks = processor.preprocess(code);
 
             assert.strictEqual(blocks.length, 1);
+            assert.strictEqual(blocks[0].filename, "0.javascript");
         });
 
         it("should find code fences with node info string", () => {
@@ -244,6 +246,7 @@ describe("processor", () => {
             const blocks = processor.preprocess(code);
 
             assert.strictEqual(blocks.length, 1);
+            assert.strictEqual(blocks[0].filename, "0.node");
         });
 
         it("should find code fences with jsx info string", () => {
@@ -255,6 +258,7 @@ describe("processor", () => {
             const blocks = processor.preprocess(code);
 
             assert.strictEqual(blocks.length, 1);
+            assert.strictEqual(blocks[0].filename, "0.jsx");
         });
 
         it("should find code fences ignoring info string case", () => {
@@ -266,6 +270,7 @@ describe("processor", () => {
             const blocks = processor.preprocess(code);
 
             assert.strictEqual(blocks.length, 1);
+            assert.strictEqual(blocks[0].filename, "0.JavaScript");
         });
 
         it("should ignore anything after the first word of the info string", () => {
@@ -277,6 +282,19 @@ describe("processor", () => {
             const blocks = processor.preprocess(code);
 
             assert.strictEqual(blocks.length, 1);
+            assert.strictEqual(blocks[0].filename, "0.js");
+        });
+
+        it("should ignore leading whitespace in the info string", () => {
+            const code = [
+                "```  js ignores leading whitespace",
+                "var answer = 6 * 7;",
+                "```"
+            ].join("\n");
+            const blocks = processor.preprocess(code);
+
+            assert.strictEqual(blocks.length, 1);
+            assert.strictEqual(blocks[0].filename, "0.js");
         });
 
         it("should find code fences not surrounded by blank lines", () => {
@@ -293,6 +311,8 @@ describe("processor", () => {
             const blocks = processor.preprocess(code);
 
             assert.strictEqual(blocks.length, 2);
+            assert.strictEqual(blocks[0].filename, "0.js");
+            assert.strictEqual(blocks[1].filename, "1.js");
         });
 
         it("should return the source code in the block", () => {


### PR DESCRIPTION
This was working correctly in v1 but stopped working when v2 switched to the new processor API. The generated filename was `0.js more words are ignored`. The test case for this was insufficiently strict: it asserted that the code block was extracted, which was sufficient with hard-coded extensions in v1, but it didn't assert the generated name was `0.js` now that we're taking the extension from the info string.

Per [CommonMark 0.29]:

> The line with the opening code fence may optionally contain some text following the code fence; this is trimmed of leading and trailing whitespace and called the info string.

I've strengthened the tests for generated filename extensions and added a new test to ensure that leading whitespace is trimmed correctly.

[CommonMark 0.29]: https://spec.commonmark.org/0.29/#info-string