### PR TITLE
Fix: npm prepare script on Windows (refs #166)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,16 @@ jobs:
 
   test:
     name: Test
-    runs-on: ubuntu-latest
     strategy:
       matrix:
+        os: [ubuntu-latest]
         node-version: ["8.10.0", 8.x, 10.x, 12.x, 13.x, 14.x]
+        include:
+        - os: windows-latest
+          node: "12.x"
+        - os: macOS-latest
+          node: "12.x"
+    runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout
       uses: actions/checkout@v1

--- a/npm-prepare.js
+++ b/npm-prepare.js
@@ -1,3 +1,9 @@
+/**
+ * @fileoverview Install examples' dependencies as part of local npm install for
+ * development and CI.
+ * @author btmills
+ */
+
 "use strict";
 
 const childProcess = require("child_process");

--- a/npm-prepare.js
+++ b/npm-prepare.js
@@ -1,0 +1,14 @@
+"use strict";
+
+const childProcess = require("child_process");
+const fs = require("fs");
+const path = require("path");
+
+const examplesDir = path.resolve(__dirname, "examples");
+const examples = fs.readdirSync(examplesDir);
+
+for (const example of examples) {
+    childProcess.execSync("npm install", {
+        cwd: path.resolve(examplesDir, example)
+    });
+}

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   ],
   "scripts": {
     "lint": "eslint --ext js,md .",
-    "prepare": "for example in examples/*; do (cd \"$example\" && npm install); done",
+    "prepare": "node ./npm-prepare.js",
     "test": "npm run lint && npm run test-cov",
     "test-cov": "nyc _mocha -- -c tests/{examples,lib}/**/*.js",
     "generate-release": "eslint-generate-release",

--- a/tests/lib/plugin.js
+++ b/tests/lib/plugin.js
@@ -55,7 +55,7 @@ describe("recommended config", () => {
                 // hook-level timeouts uses `this`, so disable the rule.
                 // https://mochajs.org/#hook-level
                 // eslint-disable-next-line no-invalid-this
-                this.timeout(9999);
+                this.timeout(30000);
 
                 execSync("npm link && npm link eslint-plugin-markdown");
             } else {


### PR DESCRIPTION
#166 originally reported being unable to `npm install` in the repository on Windows. This was due to the changes in #164, which worked fine on Linux and macOS but not Windows. This PR first adds macOS and Windows to the test matrix and then fixes the npm prepare script by moving the previous bash-only logic into JS.