### PR TITLE
Update: Upgrade remark-parse to v7 (fixes #77, fixes #78)

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "nyc": "^14.1.1"
   },
   "dependencies": {
-    "remark-parse": "^5.0.0",
+    "remark-parse": "^7.0.0",
     "unified": "^6.1.2"
   },
   "peerDependencies": {

--- a/tests/lib/plugin.js
+++ b/tests/lib/plugin.js
@@ -145,6 +145,21 @@ describe("plugin", () => {
         assert.strictEqual(report.results[0].messages[1].endLine, 8);
     });
 
+    // https://github.com/eslint/eslint-plugin-markdown/issues/77
+    it("should emit correct line numbers with leading blank line", () => {
+        const code = [
+            "### Heading",
+            "",
+            "```js",
+            "",
+            "console.log('a')",
+            "```"
+        ].join("\n");
+        const report = cli.executeOnText(code, "test.md");
+
+        assert.strictEqual(report.results[0].messages[0].line, 5);
+    });
+
     it("doesn't add end locations to messages without them", () => {
         const code = [
             "```js",
@@ -277,6 +292,23 @@ describe("plugin", () => {
             assert.strictEqual(report.results[0].messages[3].line, 15);
         });
 
+        // https://github.com/eslint/eslint-plugin-markdown/issues/78
+        it("preserves leading empty lines", () => {
+            const code = [
+                "<!-- eslint lines-around-directive: ['error', 'never'] -->",
+                "",
+                "```js",
+                "",
+                "\"use strict\";",
+                "```"
+            ].join("\n");
+            const report = cli.executeOnText(code, "test.md");
+
+            assert.strictEqual(report.results.length, 1);
+            assert.strictEqual(report.results[0].messages.length, 1);
+            assert.strictEqual(report.results[0].messages[0].message, "Unexpected newline before \"use strict\" directive.");
+            assert.strictEqual(report.results[0].messages[0].line, 5);
+        });
     });
 
     describe("should fix code", () => {

--- a/tests/lib/processor.js
+++ b/tests/lib/processor.js
@@ -199,7 +199,21 @@ describe("processor", () => {
 
             assert.strictEqual(blocks.length, 1);
             assert.strictEqual(blocks[0].filename, "0.js");
-            assert.strictEqual(blocks[0].text, "\n\n \n  \n");
+            assert.strictEqual(blocks[0].text, "\n\n\n \n  \n");
+        });
+
+        it("should preserve leading and trailing empty lines", () => {
+            const code = [
+                "```js",
+                "",
+                "console.log(42);",
+                "",
+                "```"
+            ].join("\n");
+            const blocks = processor.preprocess(code);
+
+            assert.strictEqual(blocks[0].filename, "0.js");
+            assert.strictEqual(blocks[0].text, "\nconsole.log(42);\n\n");
         });
 
         it("should ignore code fences with unspecified info string", () => {


### PR DESCRIPTION
[`remark-parse@7.0.0`](https://github.com/remarkjs/remark/releases/tag/remark-parse%407.0.0) includes https://github.com/remarkjs/remark/pull/423, which fixes handling of leading and trailing newlines in fenced code blocks.

**For reviewers:**

1. `remark-parse` v6, v7, and v8 were semver-major fixes. v9 was a full rewrite. Are we comfortable with a parser major version bump in a semver-minor release? This is currently tagged as `Update:` so it's semver-minor rather than semver-patch.
2. If so, how far? This PR bumps to v7 because it fixes two known issues, #77 and #78. I'm not aware of any `eslint-plugin-markdown` issues that would be fixed by v8 or v9.
3. If we're fine upgrading past v7 for speculative parsing accuracy improvements that don't knowingly affect `eslint-plugin-markdown`, should we stop at v8 or go all the way to the re-written parser in v9? If the latter, I'll close this in favor of #171.

**Changelogs:**

- [`remark-parse@6.0.0`](https://github.com/remarkjs/remark/releases/tag/remark-parse%406.0.0)
- [`remark-parse@7.0.0`](https://github.com/remarkjs/remark/releases/tag/remark-parse%407.0.0)
- [`remark-parse@8.0.0`](https://github.com/remarkjs/remark/releases/tag/remark-parse%408.0.0)
- [`remark-parse@9.9.0`](https://github.com/remarkjs/remark/releases/tag/13.0.0)