### PR TITLE
Chore: add yarn.lock and package-lock.json into .gitignore just like eslint/eslint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ node_modules/
 npm-debug.log
 .eslint-release-info.json
 .nyc_output
+yarn.lock
+package-lock.json


### PR DESCRIPTION
https://github.com/eslint/eslint-plugin-markdown/pull/182#discussion_r603764071