### PR TITLE
Chore: ignore `pnpm-lock.yaml`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ npm-debug.log
 .nyc_output
 yarn.lock
 package-lock.json
+pnpm-lock.yaml


### PR DESCRIPTION
Ignore `pnpm-lock.yaml` for `pnpm` users. We already ignore `package-lock.json` and `yarn.lock`.