### PR TITLE
chore: add tests for ESLint 8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Install Node.js
       uses: actions/setup-node@v2
       with:
-        node-version: '16.x'
+        node-version: 16
     - name: Install Packages
       run: npm install
       env:
@@ -29,13 +29,19 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        eslint: [6, 7]
-        node: ['8.10.0', 8, 10, 12, 14, 16]
+        eslint: [6, 7, 8]
+        node: [8.10.0, 8, 10, 12, 14, 16]
         exclude:
+          - eslint: 8
+            node: 10
+          - eslint: 8
+            node: 8
+          - eslint: 8
+            node: 8.10.0
           - eslint: 7
             node: 8
           - eslint: 7
-            node: '8.10.0'
+            node: 8.10.0
         include:
           - os: windows-latest
             eslint: 7

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "mdast-util-from-markdown": "^0.8.5"
   },
   "peerDependencies": {
-    "eslint": ">=6.0.0"
+    "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
   },
   "engines": {
     "node": "^8.10.0 || ^10.12.0 || >=12.0.0"


### PR DESCRIPTION
ESLint v8.0.0 is [released](https://eslint.org/blog/2021/10/eslint-v8.0.0-released) 🎉

devDependency compatibility with ESLint 8:

- [ ] [`eslint-config-eslint`](https://github.com/eslint/eslint/tree/master/packages/eslint-config-eslint)
  - [ ] PR
  - [ ] Release
- [x] [`eslint-plugin-jsdoc`](https://github.com/gajus/eslint-plugin-jsdoc) (https://github.com/gajus/eslint-plugin-jsdoc/issues/791)
  - [x] https://github.com/gajus/eslint-plugin-jsdoc/pull/792
  - [x] [`v37.0.0`](https://github.com/gajus/eslint-plugin-jsdoc/releases/tag/v37.0.0)
- [ ] [`eslint-plugin-node`](https://github.com/mysticatea/eslint-plugin-node) (https://github.com/mysticatea/eslint-plugin-node/issues/294)
  - [ ] https://github.com/mysticatea/eslint-plugin-node/pull/224
  - [ ] https://github.com/mysticatea/eslint-plugin-node/pull/295
  - [ ] Release

---

Closes #194