### PR TITLE
ci: use node `v16`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
       uses: actions/checkout@v2
     - name: Install Node.js
       uses: actions/setup-node@v2
+      with:
+        node-version: '16.x'
     - name: Install Packages
       run: npm install
       env:


### PR DESCRIPTION
Use node LTS version (v16) for jobs on CI.