### PR TITLE
chore: Check for package.json in examples

### DIFF
--- a/npm-prepare.js
+++ b/npm-prepare.js
@@ -11,7 +11,9 @@ const fs = require("fs");
 const path = require("path");
 
 const examplesDir = path.resolve(__dirname, "examples");
-const examples = fs.readdirSync(examplesDir);
+const examples = fs.readdirSync(examplesDir)
+    .filter(exampleDir => fs.statSync(path.join(examplesDir, exampleDir)).isDirectory())
+    .filter(exampleDir => fs.existsSync(path.join(examplesDir, exampleDir, "package.json")));
 
 for (const example of examples) {
     childProcess.execSync("npm install", {

--- a/tests/examples/all.js
+++ b/tests/examples/all.js
@@ -5,9 +5,13 @@ const fs = require("fs");
 const path = require("path");
 const semver = require("semver");
 
-const examples = path.resolve(__dirname, "../../examples/");
-for (const example of fs.readdirSync(examples)) {
-    const cwd = path.join(examples, example);
+const examplesDir = path.resolve(__dirname, "../../examples/");
+const examples = fs.readdirSync(examplesDir)
+    .filter(exampleDir => fs.statSync(path.join(examplesDir, exampleDir)).isDirectory())
+    .filter(exampleDir => fs.existsSync(path.join(examplesDir, exampleDir, "package.json")));
+
+for (const example of examples) {
+    const cwd = path.join(examplesDir, example);
 
     // The plugin officially supports ESLint as early as v6, but the examples
     // use ESLint v7, which has a higher minimum Node.js version than does v6.


### PR DESCRIPTION
Previously, OS-created hidden files like `.DS_Store` in `examples/` would cause the prepare and test scripts to throw `ENOTDIR`. They now filter for directories that contain a `package.json` before installing dependencies or running tests.