### PR TITLE
docs: update badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # eslint-plugin-markdown
 
 [![npm Version](https://img.shields.io/npm/v/eslint-plugin-markdown.svg)](https://www.npmjs.com/package/eslint-plugin-markdown)
-[![Build Status](https://img.shields.io/github/workflow/status/eslint/eslint-plugin-markdown/CI/main.svg)](https://github.com/eslint/eslint-plugin-markdown/actions)
+[![Downloads](https://img.shields.io/npm/dm/eslint-plugin-markdown.svg)](https://www.npmjs.com/package/eslint-plugin-markdown)
+[![Build Status](https://github.com/eslint/eslint-plugin-markdown/workflows/CI/badge.svg)](https://github.com/eslint/eslint-plugin-markdown/actions)
 
 Lint JS, JSX, TypeScript, and more inside Markdown.
 


### PR DESCRIPTION
Updates README.md:

* Adds the Downloads badge for consistency with other projects.
* ~Updates the Build Status badge from Travis to GitHub Actions.~

Edit: I thought the Build Status badge is still getting the status from Travis due to its appearance, but it was already GitHub Actions, so this updates only the image. Do we want to use the one from `img.shields.io` (as it is now) or the one from `github.com` (as it is in [eslint/eslint](https://github.com/eslint/eslint/blob/b93af98b3c417225a027cabc964c38e779adb945/README.md?plain=1#L3))?