### PR TITLE
ci: Prevent recursive prepare script invocations

### DIFF
--- a/npm-prepare.js
+++ b/npm-prepare.js
@@ -6,17 +6,23 @@
 
 "use strict";
 
-const childProcess = require("child_process");
-const fs = require("fs");
-const path = require("path");
+if (!process.env.NO_RECURSIVE_PREPARE) {
+    const childProcess = require("child_process");
+    const fs = require("fs");
+    const path = require("path");
 
-const examplesDir = path.resolve(__dirname, "examples");
-const examples = fs.readdirSync(examplesDir)
-    .filter(exampleDir => fs.statSync(path.join(examplesDir, exampleDir)).isDirectory())
-    .filter(exampleDir => fs.existsSync(path.join(examplesDir, exampleDir, "package.json")));
+    const examplesDir = path.resolve(__dirname, "examples");
+    const examples = fs.readdirSync(examplesDir)
+        .filter(exampleDir => fs.statSync(path.join(examplesDir, exampleDir)).isDirectory())
+        .filter(exampleDir => fs.existsSync(path.join(examplesDir, exampleDir, "package.json")));
 
-for (const example of examples) {
-    childProcess.execSync("npm install", {
-        cwd: path.resolve(examplesDir, example)
-    });
+    for (const example of examples) {
+        childProcess.execSync("npm install", {
+            cwd: path.resolve(examplesDir, example),
+            env: {
+                ...process.env,
+                NO_RECURSIVE_PREPARE: "true"
+            }
+        });
+    }
 }


### PR DESCRIPTION
A change between npm 8.9 and 8.10 started running the main package's `prepare` script as part of the examples' installs. This broke CI when the install step launched a fork bomb and got killed after several minutes.

I've left a comment on https://github.com/npm/cli/issues/4895, which appears to be related.

This change should fix builds on `main`.