### PR TITLE
ci: add Node v19

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         eslint: [6, 7, 8]
-        node: [12.22.0, 14, 16, 18]
+        node: [12.22.0, 14, 16, 18, 19]
         include:
           - os: windows-latest
             eslint: 7


### PR DESCRIPTION
Adds Node v19 to `ci.yml`.

https://nodejs.org/en/blog/release/v19.0.0/