### PR TITLE
ci: run tests in Node.js 21

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         eslint: [6, 7, 8]
-        node: [12.22.0, 14, 16, 17, 18, 19, 20]
+        node: [12.22.0, 14, 16, 17, 18, 19, 20, 21]
         include:
           - os: windows-latest
             eslint: 7


### PR DESCRIPTION
This PR updates the GitHub Actions CI workflow to run tests also in Node.js 21.