### PR TITLE
feat!: bump `mdast-util-from-markdown` with `synckit`

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,8 +3,19 @@
 module.exports = [
     ...require("eslint-config-eslint/cjs").map(config => ({
         ...config,
-        files: ["**/*.js"]
+        files: ["**/*.js", "**/*.mjs"]
     })),
+    {
+        files: ["**/*.mjs"],
+        languageOptions: {
+            sourceType: "module",
+            parserOptions: {
+                ecmaFeatures: {
+                    impliedStrict: true
+                }
+            }
+        }
+    },
     {
         plugins: {
             markdown: require(".")

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -27,8 +27,11 @@
 
 "use strict";
 
-const parse = require("mdast-util-from-markdown");
+const { createSyncFn } = require("synckit");
+
 const pkg = require("../package.json");
+
+const parse = createSyncFn(require.resolve("./worker.mjs"));
 
 const UNSATISFIABLE_RULES = new Set([
     "eol-last", // The Markdown parser strips trailing newlines in code fences

--- a/lib/worker.mjs
+++ b/lib/worker.mjs
@@ -1,0 +1,4 @@
+import { fromMarkdown } from "mdast-util-from-markdown";
+import { runAsWorker } from "synckit";
+
+runAsWorker(fromMarkdown);

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
   "files": [
     "index.js",
     "lib/index.js",
-    "lib/processor.js"
+    "lib/processor.js",
+    "lib/worker.mjs"
   ],
   "devDependencies": {
     "@eslint/js": "^8.56.0",
@@ -46,7 +47,8 @@
     "nyc": "^14.1.1"
   },
   "dependencies": {
-    "mdast-util-from-markdown": "^0.8.5"
+    "mdast-util-from-markdown": "^2.0.0",
+    "synckit": "^0.9.0"
   },
   "peerDependencies": {
     "eslint": ">=8"


### PR DESCRIPTION
close #218, drop node 12

`mdast-util-from-markdown` is ESM only now, [`synckit`](https://github.com/un-ts/synckit) makes it possible to require ESM only module in commonjs without `await import()`.

cc @btmills @nzakas 