### PR TITLE
feat: add `meta` property

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -6,6 +6,7 @@
 "use strict";
 
 const processor = require("./processor");
+const pkg = require("../package.json");
 
 const rulesConfig = {
 
@@ -31,6 +32,10 @@ const rulesConfig = {
 };
 
 const plugin = {
+    meta: {
+        name: pkg.name,
+        version: pkg.version
+    },
     processors: {
         markdown: processor
     },

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -28,6 +28,7 @@
 "use strict";
 
 const parse = require("mdast-util-from-markdown");
+const pkg = require("../package.json");
 
 const UNSATISFIABLE_RULES = new Set([
     "eol-last", // The Markdown parser strips trailing newlines in code fences
@@ -398,6 +399,10 @@ function postprocess(messages, filename) {
 }
 
 module.exports = {
+    meta: {
+        name: `${pkg.name}/markdown`,
+        version: pkg.version
+    },
     preprocess,
     postprocess,
     supportsAutofix: SUPPORTS_AUTOFIX

--- a/tests/lib/plugin.js
+++ b/tests/lib/plugin.js
@@ -13,6 +13,7 @@ const assert = require("chai").assert;
 const { LegacyESLint, FlatESLint } = require("eslint/use-at-your-own-risk");
 const path = require("path");
 const plugin = require("../..");
+const pkg = require("../../package.json");
 
 //-----------------------------------------------------------------------------
 // Helpers
@@ -54,6 +55,12 @@ function initFlatESLint(fixtureConfigName, options = {}) {
 //-----------------------------------------------------------------------------
 // Tests
 //-----------------------------------------------------------------------------
+
+describe("meta", () => {
+    it("should export meta property", () => {
+        assert.deepStrictEqual(plugin.meta, { name: "eslint-plugin-markdown", version: pkg.version });
+    });
+});
 
 describe("LegacyESLint", () => {
 

--- a/tests/lib/processor.js
+++ b/tests/lib/processor.js
@@ -7,8 +7,15 @@
 
 const assert = require("chai").assert;
 const processor = require("../../lib/processor");
+const pkg = require("../../package.json");
 
 describe("processor", () => {
+
+    describe("meta", () => {
+        it("should have meta property", () => {
+            assert.deepStrictEqual(processor.meta, { name: "eslint-plugin-markdown/markdown", version: pkg.version });
+        });
+    });
 
     describe("preprocess", () => {
 


### PR DESCRIPTION
Adds `meta` property to the plugin object and the processor object, for serialization purposes.

With this config:

```js
// eslint.config.js
import markdown from "eslint-plugin-markdown";

export default [
    {
        files: ["**/*.md"],
        plugins: { markdown },
        processor: "markdown/markdown"
    }
];

```

`eslint --print-config foo.md` will print:

```
{
  "languageOptions": {
    "ecmaVersion": "latest",
    "sourceType": "module",
    "parser": "espree@9.6.1",
    "parserOptions": {},
    "globals": {}
  },
  "processor": "markdown/markdown",
  "plugins": [
    "@",
    "markdown:eslint-plugin-markdown@3.0.1"
  ],
  "rules": {}
}
```

With this config (processor is used directly):

```js
// eslint.config.js
import markdown from "eslint-plugin-markdown";

export default [
    {
        files: ["**/*.md"],
        processor: markdown.processors.markdown
    }
];

```

`eslint --print-config foo.md` will print:

```
{
  "languageOptions": {
    "ecmaVersion": "latest",
    "sourceType": "module",
    "parser": "espree@9.6.1",
    "parserOptions": {},
    "globals": {}
  },
  "processor": "eslint-plugin-markdown/markdown@3.0.1",
  "plugins": [
    "@"
  ],
  "rules": {}
}
```