### PR TITLE
chore: remove unused `@eslint/eslintrc` in test examples

### DIFF
--- a/examples/react/eslint.config.js
+++ b/examples/react/eslint.config.js
@@ -1,13 +1,8 @@
 "use strict";
 
-const { FlatCompat } = require("@eslint/eslintrc");
 const markdown = require("eslint-plugin-markdown");
 const js = require("@eslint/js");
 const globals = require("globals");
-
-const compat = new FlatCompat({
-    baseDirectory: __dirname
-});
 
 module.exports = [
     js.configs.recommended,

--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -4,7 +4,6 @@
     "test": "eslint ."
   },
   "devDependencies": {
-    "@eslint/eslintrc": "^3.0.0",
     "@eslint/js": "^8.56.0",
     "eslint": "^8.56.0",
     "eslint-plugin-markdown": "file:../..",


### PR DESCRIPTION
Since the react test example uses eslint-plugin-react's flat config export, `@eslint/eslintrc` is unused in that test project.