### PR TITLE
test: use latest `typescript-eslint` in examples

### DIFF
--- a/examples/typescript/README.md
+++ b/examples/typescript/README.md
@@ -17,9 +17,9 @@ $ npm install
 $ npm test
 
 eslint-plugin-markdown/examples/typescript/README.md
-   6:22  error    Don’t use `String` as a type. Use string instead  @typescript-eslint/ban-types
-  10:13  warning  Unexpected any. Specify a different type          @typescript-eslint/no-explicit-any
+   6:22  error  Don't use `String` as a type. Use string instead  @typescript-eslint/ban-types
+  10:13  error  Unexpected any. Specify a different type          @typescript-eslint/no-explicit-any
 
-✖ 2 problems (1 error, 1 warning)
+✖ 2 problems (2 errors, 0 warnings)
   1 error and 0 warnings potentially fixable with the `--fix` option.
 ```

--- a/examples/typescript/eslint.config.js
+++ b/examples/typescript/eslint.config.js
@@ -2,13 +2,9 @@
 
 const markdown = require("eslint-plugin-markdown");
 const js = require("@eslint/js")
-const { FlatCompat } = require("@eslint/eslintrc");
+const tseslint = require("typescript-eslint");
 
-const compat = new FlatCompat({
-    baseDirectory: __dirname
-});
-
-module.exports = [
+module.exports = tseslint.config(
     js.configs.recommended,
     ...markdown.configs.recommended,
     {
@@ -17,11 +13,8 @@ module.exports = [
             sourceType: "commonjs"
         }
     },
-    ...compat.config({
-        parser: "@typescript-eslint/parser",
-        extends: ["plugin:@typescript-eslint/recommended"]
-    }).map(config => ({
+    ...tseslint.configs.recommended.map(config => ({
         ...config,
         files: ["**/*.ts"]
     }))
-];
+);

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -4,12 +4,10 @@
     "test": "eslint ."
   },
   "devDependencies": {
-    "@eslint/eslintrc": "^3.0.0",
     "@eslint/js": "^8.56.0",
-    "@typescript-eslint/eslint-plugin": "^6.20.0",
-    "@typescript-eslint/parser": "^6.20.0",
     "eslint": "^8.56.0",
     "eslint-plugin-markdown": "file:../..",
-    "typescript": "^3.9.7"
+    "typescript": "^5.3.3",
+    "typescript-eslint": "^7.0.1"
   }
 }


### PR DESCRIPTION
Updates examples/typescript test project to use the new package [`typescript-eslint`](https://www.npmjs.com/package/typescript-eslint) that supports flat config.

Note that `@typescript-eslint/parser` and `@typescript-eslint/eslint-plugin` are dependencies of `typescript-eslint` so there's no need to install them separately.

Configuration in eslint.config.js is based on the first example from https://typescript-eslint.io/linting/configs.