### PR TITLE
chore: add `.vscode` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+.vscode
 coverage/
 node_modules/
 npm-debug.log


### PR DESCRIPTION
Adds `.vscode` to `.gitignore`, as in other repos, so that contributors can change their VS Code settings without these files being marked as changed. Particularly useful at the moment since `eslint.experimental.useFlatConfig` should be enabled in vscode-eslint settings.