### PR TITLE
docs: fix expected errors in react example

### DIFF
--- a/examples/react/README.md
+++ b/examples/react/README.md
@@ -17,8 +17,7 @@ $ npm install
 $ npm test
 
 eslint-plugin-markdown/examples/react/README.md
-  4:10  error  'App' is defined but never used        no-unused-vars
   4:16  error  'name' is missing in props validation  react/prop-types
 
-✖ 2 problems (2 errors, 0 warnings)
+✖ 1 problem (1 error, 0 warnings)
 ```


### PR DESCRIPTION
Fixes `examples/react/README.md`, the part with expected errors. This plugin's `recommended` config disables the `no-unused-var` rule, so errors for this rule don't appear when linting the react example project.

https://github.com/eslint/eslint-plugin-markdown/blob/cbb8e3afc665d314570a9b087c7cef2e97d45860/lib/index.js#L21