### PR TITLE
chore: update changelog with note that v4.0.0 was not published to npm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [4.0.0](https://github.com/eslint/eslint-plugin-markdown/compare/v3.0.1...v4.0.0) (2024-03-01)
 
+⚠️ This release was not published to npm due to technical problems.
 
 ### ⚠ BREAKING CHANGES
 


### PR DESCRIPTION
Adds a note that v4.0.0 was not published to npm.

Once this is approved and merged, I'll update https://github.com/eslint/eslint-plugin-markdown/releases/tag/v4.0.0 with the same text.

