### PR TITLE
feat!: map known code block languages to respective file extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The virtual filename's extension will match the fenced code block's syntax tag, 
 * `typescript` is mapped to `ts`
 * `markdown` is mapped to `md`
 
-For example, <code>```js</code> code blocks in `README.md` would match `README.md/*.js` and <code>``typescript</code> in `CONTRIBUTING.md` would match `CONTRIBUTING.md/*.ts`.
+For example, ```` ```js ```` code blocks in `README.md` would match `README.md/*.js` and ```` ```typescript ```` in `CONTRIBUTING.md` would match `CONTRIBUTING.md/*.ts`.
 
 You can use glob patterns for these virtual filenames to customize configuration for code blocks without affecting regular code.
 For more information on configuring processors, refer to the [ESLint documentation](https://eslint.org/docs/user-guide/configuring#specifying-processor).

--- a/README.md
+++ b/README.md
@@ -53,7 +53,10 @@ You can manually include the Markdown processor by setting the `processor` optio
 
 Each fenced code block inside a Markdown document has a virtual filename appended to the Markdown file's path.
 
-The virtual filename's extension will match the fenced code block's syntax tag, so for example, <code>```js</code> code blocks in <code>README.md</code> would match <code>README.md/*.js</code>.
+The virtual filename's extension will match the fenced code block's syntax tag, except for the following: `javascript`, `ecmascript`, `typescript` and `markdown`.
+The exceptions are mapped to their shorter syntax tag variants: `js`, `js`, `ts` and `md` respectively.
+So for example, <code>```js</code> code blocks in <code>README.md</code> would match <code>README.md/*.js</code> and <code>``typescript</code> in <code>CONTRIBUTING.md</code> would match <code>CONTRIBUTING.md/*.ts</code>.
+
 You can use glob patterns for these virtual filenames to customize configuration for code blocks without affecting regular code.
 For more information on configuring processors, refer to the [ESLint documentation](https://eslint.org/docs/user-guide/configuring#specifying-processor).
 

--- a/README.md
+++ b/README.md
@@ -53,9 +53,13 @@ You can manually include the Markdown processor by setting the `processor` optio
 
 Each fenced code block inside a Markdown document has a virtual filename appended to the Markdown file's path.
 
-The virtual filename's extension will match the fenced code block's syntax tag, except for the following: `javascript`, `ecmascript`, `typescript` and `markdown`.
-The exceptions are mapped to their shorter syntax tag variants: `js`, `js`, `ts` and `md` respectively.
-So for example, <code>```js</code> code blocks in <code>README.md</code> would match <code>README.md/*.js</code> and <code>``typescript</code> in <code>CONTRIBUTING.md</code> would match <code>CONTRIBUTING.md/*.ts</code>.
+The virtual filename's extension will match the fenced code block's syntax tag, except for the following: 
+
+* `javascript` and `ecmascript` are mapped to `js`
+* `typescript` is mapped to `ts`
+* `markdown` is mapped to `md`
+
+For example, <code>```js</code> code blocks in `README.md` would match `README.md/*.js` and <code>``typescript</code> in `CONTRIBUTING.md` would match `CONTRIBUTING.md/*.ts`.
 
 You can use glob patterns for these virtual filenames to customize configuration for code blocks without affecting regular code.
 For more information on configuring processors, refer to the [ESLint documentation](https://eslint.org/docs/user-guide/configuring#specifying-processor).

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -41,7 +41,13 @@ module.exports = [
         },
         rules: {
             "lines-around-comment": "off",
-            "n/no-missing-import": "off"
+            "n/no-missing-import": "off",
+            "no-var": "off",
+            "padding-line-between-statements": "off",
+            "no-console": "off",
+            "no-alert": "off",
+            "eslint-comments/require-description": "off",
+            "jsdoc/require-jsdoc": "off"
         }
     }
 ];

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -237,7 +237,6 @@ function getBlockRangeMap(text, node, comments) {
 
 const languageToFileExtension = {
     javascript: "js",
-    node: "js",
     ecmascript: "js",
     typescript: "ts",
     markdown: "md"

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -235,6 +235,14 @@ function getBlockRangeMap(text, node, comments) {
     return rangeMap;
 }
 
+const languageToFileExtension = {
+    javascript: "js",
+    node: "js",
+    ecmascript: "js",
+    typescript: "ts",
+    markdown: "md"
+};
+
 /**
  * Extracts lintable code blocks from Markdown text.
  * @param {string} text The text of the file.
@@ -295,14 +303,19 @@ function preprocess(text, filename) {
         }
     });
 
-    return blocks.map((block, index) => ({
-        filename: `${index}.${block.lang.trim().split(" ")[0]}`,
-        text: [
-            ...block.comments,
-            block.value,
-            ""
-        ].join("\n")
-    }));
+    return blocks.map((block, index) => {
+        const [language] = block.lang.trim().split(" ");
+        const fileExtension = Object.hasOwn(languageToFileExtension, language) ? languageToFileExtension[language] : language;
+
+        return {
+            filename: `${index}.${fileExtension}`,
+            text: [
+                ...block.comments,
+                block.value,
+                ""
+            ].join("\n")
+        };
+    });
 }
 
 /**

--- a/tests/lib/processor.js
+++ b/tests/lib/processor.js
@@ -115,7 +115,7 @@ describe("processor", () => {
                 "```js",
                 "backticks",
                 "```",
-                "~~~javascript",
+                "~~~js",
                 "tildes",
                 "~~~"
             ].join("\n");
@@ -124,7 +124,7 @@ describe("processor", () => {
             assert.strictEqual(blocks.length, 2);
             assert.strictEqual(blocks[0].filename, "0.js");
             assert.strictEqual(blocks[0].text, "backticks\n");
-            assert.strictEqual(blocks[1].filename, "1.javascript");
+            assert.strictEqual(blocks[1].filename, "1.js");
             assert.strictEqual(blocks[1].text, "tildes\n");
         });
 
@@ -255,7 +255,7 @@ describe("processor", () => {
             const blocks = processor.preprocess(code);
 
             assert.strictEqual(blocks.length, 1);
-            assert.strictEqual(blocks[0].filename, "0.javascript");
+            assert.strictEqual(blocks[0].filename, "0.js");
         });
 
         it("should find code fences with node info string", () => {
@@ -267,7 +267,7 @@ describe("processor", () => {
             const blocks = processor.preprocess(code);
 
             assert.strictEqual(blocks.length, 1);
-            assert.strictEqual(blocks[0].filename, "0.node");
+            assert.strictEqual(blocks[0].filename, "0.js");
         });
 
         it("should find code fences with jsx info string", () => {
@@ -321,6 +321,18 @@ describe("processor", () => {
         it("should ignore trailing whitespace in the info string", () => {
             const code = [
                 "```js    ",
+                "var answer = 6 * 7;",
+                "```"
+            ].join("\n");
+            const blocks = processor.preprocess(code);
+
+            assert.strictEqual(blocks.length, 1);
+            assert.strictEqual(blocks[0].filename, "0.js");
+        });
+
+        it("should the language to its file extension with leading whitespace and trailing characters", () => {
+            const code = [
+                "```   javascript  CUSTOM",
                 "var answer = 6 * 7;",
                 "```"
             ].join("\n");
@@ -408,7 +420,7 @@ describe("processor", () => {
                 "var answer = 6 * 7;",
                 "```",
                 "",
-                "```javascript",
+                "```js",
                 "console.log(answer);",
                 "```",
                 "",
@@ -419,7 +431,7 @@ describe("processor", () => {
             assert.strictEqual(blocks.length, 2);
             assert.strictEqual(blocks[0].filename, "0.js");
             assert.strictEqual(blocks[0].text, "var answer = 6 * 7;\n");
-            assert.strictEqual(blocks[1].filename, "1.javascript");
+            assert.strictEqual(blocks[1].filename, "1.js");
             assert.strictEqual(blocks[1].text, "console.log(answer);\n");
         });
 

--- a/tests/lib/processor.js
+++ b/tests/lib/processor.js
@@ -330,7 +330,7 @@ describe("processor", () => {
             assert.strictEqual(blocks[0].filename, "0.js");
         });
 
-        it("should the language to its file extension with leading whitespace and trailing characters", () => {
+        it("should translate the language to its file extension with leading whitespace and trailing characters", () => {
             const code = [
                 "```   javascript  CUSTOM",
                 "var answer = 6 * 7;",

--- a/tests/lib/processor.js
+++ b/tests/lib/processor.js
@@ -267,7 +267,7 @@ describe("processor", () => {
             const blocks = processor.preprocess(code);
 
             assert.strictEqual(blocks.length, 1);
-            assert.strictEqual(blocks[0].filename, "0.js");
+            assert.strictEqual(blocks[0].filename, "0.node");
         });
 
         it("should find code fences with jsx info string", () => {


### PR DESCRIPTION
Fixes #245.
I researched common language codes for javascript and markdown which are not the same as the file extension.
There may be additional ones.
The current tests had test cases for the language codes `javascript` and `node` already, so I adjusted them and added a case to make sure the mapping from code block language to file extension is done after the code block language normalization.
This may be a breaking change as additional code blocks may be linted.