### PR TITLE
fix: check upper bounds of message line numbers for code blocks

### DIFF
--- a/lib/processor.js
+++ b/lib/processor.js
@@ -331,7 +331,7 @@ function adjustBlock(block) {
 
         const lineInCode = message.line - leadingCommentLines;
 
-        if (lineInCode < 1) {
+        if (lineInCode < 1 || lineInCode >= block.rangeMap.length) {
             return null;
         }
 

--- a/tests/lib/processor.js
+++ b/tests/lib/processor.js
@@ -755,6 +755,17 @@ describe("processor", () => {
             });
         });
 
+        it("should ignore messages after the code block", () => {
+            const empty = [
+                '```javascript',
+                '```',
+            ].join('\n');
+            processor.preprocess(empty, 'empty.md');
+            const message = { message: 'Empty file', ruleId: null, line: 2 };
+            const result = processor.postprocess([[message]], 'empty.md');
+
+            assert.deepStrictEqual(result, []);
+        });
     });
 
     describe("supportsAutofix", () => {

--- a/tests/lib/processor.js
+++ b/tests/lib/processor.js
@@ -757,12 +757,13 @@ describe("processor", () => {
 
         it("should ignore messages after the code block", () => {
             const empty = [
-                '```javascript',
-                '```',
-            ].join('\n');
-            processor.preprocess(empty, 'empty.md');
-            const message = { message: 'Empty file', ruleId: null, line: 2 };
-            const result = processor.postprocess([[message]], 'empty.md');
+                "```javascript",
+                "```"
+            ].join("\n");
+
+            processor.preprocess(empty, "empty.md");
+            const message = { message: "Empty file", ruleId: null, line: 2 };
+            const result = processor.postprocess([[message]], "empty.md");
 
             assert.deepStrictEqual(result, []);
         });


### PR DESCRIPTION
Fixes #244.
Added an upper guard to make sure the access to `block.rangeMap[lineNumber]` is defined as well as add a simple test case (I manually set the state via `preprocess` in the test case and not use the "shared" state from the beforeEach to make this test case clearer).