### PR TITLE
ci: run tests in Node.js 22, with ESLint 9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,14 +29,14 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        eslint: [8]
-        node: [21.x, 20.x, 18.x, "18.18.0"]
+        eslint: [9, 8]
+        node: [22.x, 21.x, 20.x, 18.x, "18.18.0"]
         include:
           - os: windows-latest
-            eslint: 8
+            eslint: 9
             node: 20
           - os: macOS-latest
-            eslint: 8
+            eslint: 9
             node: 20
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Adds Node 22 and ESLint v9 to test matrix.