### PR TITLE
build: Fix release-please tag name

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,6 +3,7 @@
     ".": {
       "release-type": "node",
       "pull-request-title-pattern": "chore: release ${version} 🚀",
+      "include-component-in-tag": false,
       "extra-files": [
         "lib/index.js",
         "lib/processor.js"


### PR DESCRIPTION
Trying to fix release-please so it creates a tag name without a component.