### PR TITLE
test: use ESLint v9 in examples

### DIFF
--- a/examples/react/README.md
+++ b/examples/react/README.md
@@ -12,8 +12,9 @@ function App({ name }) {
 
 ```sh
 $ git clone https://github.com/eslint/eslint-plugin-markdown.git
-$ cd eslint-plugin-markdown/examples/react
+$ cd eslint-plugin-markdown
 $ npm install
+$ cd examples/react
 $ npm test
 
 eslint-plugin-markdown/examples/react/README.md

--- a/examples/react/eslint.config.mjs
+++ b/examples/react/eslint.config.mjs
@@ -2,12 +2,12 @@
 import js from "@eslint/js";
 import markdown from "../../src/index.js";
 import globals from "globals";
-import reactRecommended from "eslint-plugin-react/configs/recommended.js";
+import reactPlugin from "eslint-plugin-react";
 
 export default [
     js.configs.recommended,
     ...markdown.configs.recommended,
-    reactRecommended,
+    reactPlugin.configs.flat.recommended,
     {
         settings: {
             react: {
@@ -23,12 +23,6 @@ export default [
             ecmaVersion: 2015,
             sourceType: "module",
             globals: globals.browser
-        }
-    },
-    {
-        files: ["eslint.config.js"],
-        languageOptions: {
-            sourceType: "commonjs"
         }
     },
     {

--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -4,10 +4,9 @@
     "test": "eslint ."
   },
   "devDependencies": {
-    "@eslint/js": "^8.56.0",
-    "eslint": "^8.56.0",
-    "eslint-plugin-markdown": "file:../..",
-    "eslint-plugin-react": "^7.20.3",
+    "@eslint/js": "^9.7.0",
+    "eslint": "^9.7.0",
+    "eslint-plugin-react": "^7.35.0",
     "globals": "^13.24.0"
   }
 }

--- a/examples/typescript/README.md
+++ b/examples/typescript/README.md
@@ -12,13 +12,14 @@ hello(42 as any);
 
 ```sh
 $ git clone https://github.com/eslint/eslint-plugin-markdown.git
-$ cd eslint-plugin-markdown/examples/typescript
+$ cd eslint-plugin-markdown
 $ npm install
+$ cd examples/typescript
 $ npm test
 
 eslint-plugin-markdown/examples/typescript/README.md
-   6:22  error  Don't use `String` as a type. Use string instead  @typescript-eslint/ban-types
-  10:13  error  Unexpected any. Specify a different type          @typescript-eslint/no-explicit-any
+   6:22  error  Prefer using the primitive `string` as a type name, rather than the upper-cased `String`  @typescript-eslint/no-wrapper-object-types
+  10:13  error  Unexpected any. Specify a different type                                                  @typescript-eslint/no-explicit-any
 
 ✖ 2 problems (2 errors, 0 warnings)
   1 error and 0 warnings potentially fixable with the `--fix` option.

--- a/examples/typescript/eslint.config.mjs
+++ b/examples/typescript/eslint.config.mjs
@@ -5,12 +5,6 @@ import tseslint from "typescript-eslint";
 export default tseslint.config(
     js.configs.recommended,
     ...markdown.configs.recommended,
-    {
-        files: ["eslint.config.js"],
-        languageOptions: {
-            sourceType: "commonjs"
-        }
-    },
     ...tseslint.configs.recommended.map(config => ({
         ...config,
         files: ["**/*.ts"]

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -4,10 +4,9 @@
     "test": "eslint ."
   },
   "devDependencies": {
-    "@eslint/js": "^8.56.0",
-    "eslint": "^8.56.0",
-    "eslint-plugin-markdown": "file:../..",
+    "@eslint/js": "^9.7.0",
+    "eslint": "^9.7.0",
     "typescript": "^5.3.3",
-    "typescript-eslint": "^7.0.1"
+    "typescript-eslint": "8.0.0-alpha.51"
   }
 }

--- a/tests/examples/all.test.js
+++ b/tests/examples/all.test.js
@@ -16,11 +16,11 @@ const examples = fs.readdirSync(examplesDir)
 for (const example of examples) {
     const cwd = path.join(examplesDir, example);
 
-    // The plugin officially supports ESLint as early as v6, but the examples
-    // use ESLint v8, which has a higher minimum Node.js version than does v6.
+    // In case when this plugin supports multiple major versions of ESLint,
+    // CI matrix may include Node.js versions that are not supported by
+    // the version of ESLint that is used in examples.
     // Only exercise the example if the running Node.js version satisfies the
-    // minimum version constraint. In CI, this will skip these tests in Node.js
-    // v8 and run them on all other Node.js versions.
+    // minimum version constraint.
     const eslintPackageJsonPath = require.resolve("eslint/package.json", {
         paths: [cwd]
     });


### PR DESCRIPTION
This PR updates test examples (react and typescript) to use ESLint v9. Since this plugin now supports only ESLint >=9, it doesn't make sense to test with ESLint v8.